### PR TITLE
update: set ts target es5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "lib",
-    "target": "es6",
+    "target": "es5",
     "module": "ESNext",
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
please set target es5. so that users can use it without compile again. just like what react-query does.

especially, in a legacy project like what i am working on,  it's hardly to change babel or webpack configuration.

so please merge this PR. and release a new version with es5 syntax. 