### PR TITLE
Fix: Changed src/index.ts to rexport QueryCache and MutationCache. (#38)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ export {
   QueriesObserver,
   InfiniteQueryObserver,
   MutationObserver,
+  QueryCache,
+  MutationCache,
 } from "react-query/core";
 
 export { useQueryClient, VUE_QUERY_CLIENT } from "./useQueryClient";


### PR DESCRIPTION
PR makes `QueryCache` and `MutationCache` public by re-exporting them from `src/index.ts`.

This was discussed in https://github.com/DamianOsipiuk/vue-query/issues/38