### PR TITLE
fix: remove react type reference from devtools

### DIFF
--- a/src/devtools/utils.ts
+++ b/src/devtools/utils.ts
@@ -1,4 +1,4 @@
-import type { Query } from "react-query/types";
+import type { Query } from "react-query/types/core";
 
 import type { SortFn } from "./types";
 import type { Theme } from "./useTheme";


### PR DESCRIPTION
https://github.com/DamianOsipiuk/vue-query/issues/83