### PR TITLE
fix: make use-query working with Refs

### DIFF
--- a/docs/guides/query-keys.md
+++ b/docs/guides/query-keys.md
@@ -38,11 +38,11 @@ useQuery(['todos', { type: 'done' }], ...)
 // queryKey === ['todos', { type: 'done' }]
 ```
 
-!> If your query key parameter **will change over time** in the same component, do not place it directly in the `queryKey` array. Place it inside an object as a `ref` and wrap the whole `queryKey` in `reactive`. This is due to how vue reactivity system works.
+!> If your query key parameter **will change over time** in the same component, pass every such query key parameter as a `ref` or computed value.
 
 ```js
 const id = ref(5);
-useQuery(reactive(['todo', { id }]), ...)
+useQuery(['todo', id], ...)
 ```
 
 ### Query Keys are hashed deterministically!

--- a/src/vue/__tests__/useQuery.test.ts
+++ b/src/vue/__tests__/useQuery.test.ts
@@ -84,7 +84,7 @@ describe("useQuery", () => {
     });
   });
 
-  test("should update query on reactive prop change", async () => {
+  test("should update query on reactive options object change", async () => {
     const spy = jest.fn();
     const onSuccess = ref(noop);
     useQuery(
@@ -101,6 +101,31 @@ describe("useQuery", () => {
     await flushPromises();
 
     expect(spy).toBeCalledTimes(1);
+  });
+
+  test("should update query on reactive (Ref) key change", async () => {
+    const secondKeyRef = ref("key7");
+    const query = useQuery(["key6", secondKeyRef], simpleFetcher);
+
+    await flushPromises();
+
+    expect(query).toMatchObject({
+      status: { value: "success" },
+    });
+
+    secondKeyRef.value = "key8";
+    await flushPromises();
+
+    expect(query).toMatchObject({
+      status: { value: "loading" },
+      data: { value: undefined },
+    });
+
+    await flushPromises();
+
+    expect(query).toMatchObject({
+      status: { value: "success" },
+    });
   });
 
   test("should properly execute dependant queries", async () => {


### PR DESCRIPTION
Documentation says that I need to wrap keys into `reactive` and pass an object of refs  https://vue-query.vercel.app/#/guides/query-keys
![image](https://user-images.githubusercontent.com/427621/148640212-453a39af-f747-496b-a41f-19b365bc63f3.png)

To me, as a developer, this way of passing keys seems very unnatural and unintuitive (not to say, complicated) 
In ReactQuery I used to pass just an array of primitive values, like `useQuery(['book', bookId], ....)`. 
I want to have a similar Developer experience.

This fix makes it possible to pass an array of Refs.

I also added a test which ensures it is working