### PR TITLE
Allow options accept refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,13 @@ For topics not covered in vue-query docs visit https://react-query.tanstack.com/
    });
    ```
 
-3. If you need to update options on your query dynamically, make sure to pass it as reactive property
+3. If you need to update options on your query dynamically, make sure to pass them as reactive variables
 
    ```ts
    const id = ref(1);
-   const queryKey = reactive(["todos", { id }]);
+   const queryKey = ["todos", id];
    const queryFunction = () => getTodos(id);
-   const options = reactive({
-     enabled: false,
-   });
+   const enabled = ref(false);
 
-   const query = useQuery(queryKey, queryFunction, options);
+   const query = useQuery(queryKey, queryFunction, { enabled });
    ```

--- a/docs/guides/dependent-queries.md
+++ b/docs/guides/dependent-queries.md
@@ -9,12 +9,11 @@ const enabled = computed(() => !!user.value?.id);
 
 // Then get the user's projects
 const { isIdle, data: projects } = useQuery(
-  reactive(["projects", { userId }]),
+  ["projects", userId],
   () => getProjectsByUser(userId.value),
-  reactive({
-    // The query will not execute until the userId exists
-    enabled,
-  })
+  {
+    enabled, // The query will not execute until the userId exists
+  }
 );
 
 // isIdle will be `true` until `enabled` is true and the query begins to fetch.

--- a/docs/guides/parallel-queries.md
+++ b/docs/guides/parallel-queries.md
@@ -25,7 +25,7 @@ const users = computed(...)
 const userQueries = useQueries(
   users.value.map(user => {
     return {
-      queryKey: ['user', {userId: user.id}],
+      queryKey: ['user', user.id],
       queryFn: () => fetchUserById(user.id),
     }
   })

--- a/docs/guides/placeholder-query-data.md
+++ b/docs/guides/placeholder-query-data.md
@@ -39,7 +39,7 @@ A good example of this would be searching the cached data from a blog post list 
 
 ```js
 const result = useQuery(
-  ["blogPost", { blogPostId }],
+  ["blogPost", blogPostId],
   () => fetch(`/blogPosts/${blogPostId}`),
   {
     placeholderData: () => {

--- a/docs/guides/query-functions.md
+++ b/docs/guides/query-functions.md
@@ -48,7 +48,7 @@ Query keys are not just for uniquely identifying the data you are fetching, but 
 
 ```js
 function useTodos(status, page) {
-  const result = useQuery(reactive(["todos", { status, page }]), fetchTodoList);
+  const result = useQuery(["todos", { status, page }], fetchTodoList);
 }
 
 // Access the key, status and page variables in your query function!

--- a/docs/guides/query-keys.md
+++ b/docs/guides/query-keys.md
@@ -70,9 +70,7 @@ Since query keys uniquely describe the data they are fetching, they should inclu
 
 ```js
 function useTodos(todoId) {
-  const queryKey = reactive(["todos", { todoId }]);
+  const queryKey = ["todos", todoId];
   const result = useQuery(queryKey, () => fetchTodoById(todoId.value));
 }
 ```
-
-!> `queryKeys` that depend on variables should be wrapped in `reactive`. Variables should be passed as an object as `refs`. This will guarantee that Vue reactivity system will work for you.

--- a/docs/guides/query-retries.md
+++ b/docs/guides/query-retries.md
@@ -11,7 +11,7 @@ You can configure retries both on a global level and an individual query level.
 import { useQuery } from "vue-query";
 
 // Make a specific query retry a certain number of times
-const result = useQuery(["todos"], fetchTodos, {
+const result = useQuery("todos", fetchTodos, {
   retry: 10, // Will retry failed requests 10 times before displaying an error
 });
 ```

--- a/src/vue/__tests__/useQuery.test.ts
+++ b/src/vue/__tests__/useQuery.test.ts
@@ -128,6 +128,33 @@ describe("useQuery", () => {
     });
   });
 
+  test("should update query when an option is passed as Ref and it's changed", async () => {
+    const enabled = ref(false);
+    const query = useQuery("key9", simpleFetcher, { enabled });
+
+    await flushPromises();
+
+    expect(query).toMatchObject({
+      status: { value: "idle" },
+      data: { value: undefined },
+    });
+
+    enabled.value = true;
+
+    await flushPromises();
+
+    expect(query).toMatchObject({
+      status: { value: "loading" },
+      data: { value: undefined },
+    });
+
+    await flushPromises();
+
+    expect(query).toMatchObject({
+      status: { value: "success" },
+    });
+  });
+
   test("should properly execute dependant queries", async () => {
     const { data } = useQuery("dependant1", simpleFetcher);
 

--- a/src/vue/__tests__/utils.test.ts
+++ b/src/vue/__tests__/utils.test.ts
@@ -41,7 +41,7 @@ describe("utils", () => {
       const options = { retry: false };
       const result = parseMutationArgs(options);
 
-      expect(result).toBe(options);
+      expect(result).toEqual(options);
     });
 
     test("should merge query key with options", () => {
@@ -50,7 +50,6 @@ describe("utils", () => {
       const expected = { ...options, mutationKey: "key" };
 
       expect(result).toEqual(expected);
-      expect(result).toBe(options);
     });
 
     test("should merge query fn with options", () => {
@@ -59,7 +58,6 @@ describe("utils", () => {
       const expected = { ...options, mutationFn: successMutator };
 
       expect(result).toEqual(expected);
-      expect(result).toBe(options);
     });
 
     test("should merge query key and fn with options", () => {
@@ -72,25 +70,16 @@ describe("utils", () => {
       };
 
       expect(result).toEqual(expected);
-      expect(result).toBe(options);
     });
   });
 
   describe("parseQueryArgs", () => {
-    test("should return the same instance of options", () => {
-      const options = { retry: false };
-      const result = parseQueryArgs(options);
-
-      expect(result).toBe(options);
-    });
-
     test("should merge query key with options", () => {
       const options = { retry: false };
       const result = parseQueryArgs("key", options);
       const expected = { ...options, queryKey: "key" };
 
       expect(result).toEqual(expected);
-      expect(result).toBe(options);
     });
 
     test("should merge query key and fn with options", () => {
@@ -103,7 +92,6 @@ describe("utils", () => {
       };
 
       expect(result).toEqual(expected);
-      expect(result).toBe(options);
     });
   });
 

--- a/src/vue/__tests__/utils.test.ts
+++ b/src/vue/__tests__/utils.test.ts
@@ -74,6 +74,13 @@ describe("utils", () => {
   });
 
   describe("parseQueryArgs", () => {
+    test("should return the same instance of options", () => {
+      const options = { retry: false };
+      const result = parseQueryArgs(options);
+
+      expect(result).toStrictEqual(options);
+    });
+
     test("should merge query key with options", () => {
       const options = { retry: false };
       const result = parseQueryArgs("key", options);

--- a/src/vue/types.ts
+++ b/src/vue/types.ts
@@ -1,10 +1,4 @@
-import type {
-  QueryKey,
-  QueryOptions,
-  InfiniteQueryObserverResult,
-  PlaceholderDataFunction,
-  Query,
-} from "react-query/types/core";
+import type { QueryKey, QueryObserverOptions } from "react-query/types/core";
 import { Ref } from "vue-demi";
 
 export type MaybeRef<T> = Ref<T> | T;
@@ -13,119 +7,26 @@ export type WithQueryClientKey<T> = T & { queryClientKey?: string };
 
 // A Vue version of QueriesObserverOptions from "react-query/types/core"
 // Accept refs as options
-export interface VueQueryObserverOptions<
+export type VueQueryObserverOptions<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
-> extends QueryOptions<TQueryFnData, TError, TQueryData, TQueryKey> {
-  /**
-   * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
-   * To refetch the query, use the `refetch` method returned from the `useQuery` instance.
-   * Defaults to `true`.
-   */
-  enabled?: MaybeRef<boolean>;
-  /**
-   * The time in milliseconds after data is considered stale.
-   * If set to `Infinity`, the data will never be considered stale.
-   */
-  staleTime?: MaybeRef<number>;
-  /**
-   * If set to a number, the query will continuously refetch at this frequency in milliseconds.
-   * If set to a function, the function will be executed with the latest data and query to compute a frequency
-   * Defaults to `false`.
-   */
-  refetchInterval?:
-    | MaybeRef<number | false>
-    | ((
-        data: TData | undefined,
-        query: Query<TQueryFnData, TError, TQueryData, TQueryKey>
-      ) => number | false);
-  /**
-   * If set to `true`, the query will continue to refetch while their tab/window is in the background.
-   * Defaults to `false`.
-   */
-  refetchIntervalInBackground?: MaybeRef<boolean>;
-  /**
-   * If set to `true`, the query will refetch on window focus if the data is stale.
-   * If set to `false`, the query will not refetch on window focus.
-   * If set to `'always'`, the query will always refetch on window focus.
-   * Defaults to `true`.
-   */
-  refetchOnWindowFocus?: MaybeRef<boolean | "always">;
-  /**
-   * If set to `true`, the query will refetch on reconnect if the data is stale.
-   * If set to `false`, the query will not refetch on reconnect.
-   * If set to `'always'`, the query will always refetch on reconnect.
-   * Defaults to `true`.
-   */
-  refetchOnReconnect?: MaybeRef<boolean | "always">;
-  /**
-   * If set to `true`, the query will refetch on mount if the data is stale.
-   * If set to `false`, will disable additional instances of a query to trigger background refetches.
-   * If set to `'always'`, the query will always refetch on mount.
-   * Defaults to `true`.
-   */
-  refetchOnMount?: MaybeRef<boolean | "always">;
-  /**
-   * If set to `false`, the query will not be retried on mount if it contains an error.
-   * Defaults to `true`.
-   */
-  retryOnMount?: MaybeRef<boolean>;
-  /**
-   * If set, the component will only re-render if any of the listed properties change.
-   * When set to `['data', 'error']`, the component will only re-render when the `data` or `error` properties change.
-   * When set to `tracked`, access to properties will be tracked, and the component will only re-render when one of the tracked properties change.
-   */
-  notifyOnChangeProps?: Array<keyof InfiniteQueryObserverResult> | "tracked";
-  /**
-   * If set, the component will not re-render if any of the listed properties change.
-   */
-  notifyOnChangePropsExclusions?: Array<keyof InfiniteQueryObserverResult>;
-  /**
-   * This callback will fire any time the query successfully fetches new data or the cache is updated via `setQueryData`.
-   */
-  onSuccess?: (data: TData) => void;
-  /**
-   * This callback will fire if the query encounters an error and will be passed the error.
-   */
-  onError?: (err: TError) => void;
-  /**
-   * This callback will fire any time the query is either successfully fetched or errors and be passed either the data or error.
-   */
-  onSettled?: (data: TData | undefined, error: TError | null) => void;
-  /**
-   * Whether errors should be thrown instead of setting the `error` property.
-   * If set to `true` or `suspense` is `true`, all errors will be thrown to the error boundary.
-   * If set to `false` and `suspense` is `false`, errors are returned as state.
-   * If set to a function, it will be passed the error and should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`).
-   * Defaults to `false`.
-   */
-  useErrorBoundary?: MaybeRef<boolean> | ((error: TError) => boolean);
-  /**
-   * This option can be used to transform or select a part of the data returned by the query function.
-   */
-  select?: (data: TQueryData) => TData;
-  /**
-   * If set to `true`, the query will suspend when `status === 'loading'`
-   * and throw errors when `status === 'error'`.
-   * Defaults to `false`.
-   */
-  suspense?: MaybeRef<boolean>;
-  /**
-   * Set this to `true` to keep the previous `data` when fetching based on a new query key.
-   * Defaults to `false`.
-   */
-  keepPreviousData?: MaybeRef<boolean>;
-  /**
-   * If set, this value will be used as the placeholder data for this particular query observer while the query is still in the `loading` data and no initialData has been provided.
-   */
-  placeholderData?: TQueryData | PlaceholderDataFunction<TQueryData>;
-  /**
-   * If set, the observer will optimistically set the result in fetching state before the query has actually started fetching.
-   * This is to make sure the results are not lagging behind.
-   * Defaults to `true`.
-   */
-  optimisticResults?: MaybeRef<boolean>;
-}
+> = {
+  [Property in keyof QueryObserverOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryData,
+    TQueryKey
+  >]: MaybeRef<
+    QueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey
+    >[Property]
+  >;
+};

--- a/src/vue/types.ts
+++ b/src/vue/types.ts
@@ -1,1 +1,131 @@
+import type {
+  QueryKey,
+  QueryOptions,
+  InfiniteQueryObserverResult,
+  PlaceholderDataFunction,
+  Query,
+} from "react-query/types/core";
+import { Ref } from "vue-demi";
+
+export type MaybeRef<T> = Ref<T> | T;
+
 export type WithQueryClientKey<T> = T & { queryClientKey?: string };
+
+// A Vue version of QueriesObserverOptions from "react-query/types/core"
+// Accept refs as options
+export interface VueQueryObserverOptions<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+> extends QueryOptions<TQueryFnData, TError, TQueryData, TQueryKey> {
+  /**
+   * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
+   * To refetch the query, use the `refetch` method returned from the `useQuery` instance.
+   * Defaults to `true`.
+   */
+  enabled?: MaybeRef<boolean>;
+  /**
+   * The time in milliseconds after data is considered stale.
+   * If set to `Infinity`, the data will never be considered stale.
+   */
+  staleTime?: MaybeRef<number>;
+  /**
+   * If set to a number, the query will continuously refetch at this frequency in milliseconds.
+   * If set to a function, the function will be executed with the latest data and query to compute a frequency
+   * Defaults to `false`.
+   */
+  refetchInterval?:
+    | MaybeRef<number | false>
+    | ((
+        data: TData | undefined,
+        query: Query<TQueryFnData, TError, TQueryData, TQueryKey>
+      ) => number | false);
+  /**
+   * If set to `true`, the query will continue to refetch while their tab/window is in the background.
+   * Defaults to `false`.
+   */
+  refetchIntervalInBackground?: MaybeRef<boolean>;
+  /**
+   * If set to `true`, the query will refetch on window focus if the data is stale.
+   * If set to `false`, the query will not refetch on window focus.
+   * If set to `'always'`, the query will always refetch on window focus.
+   * Defaults to `true`.
+   */
+  refetchOnWindowFocus?: MaybeRef<boolean | "always">;
+  /**
+   * If set to `true`, the query will refetch on reconnect if the data is stale.
+   * If set to `false`, the query will not refetch on reconnect.
+   * If set to `'always'`, the query will always refetch on reconnect.
+   * Defaults to `true`.
+   */
+  refetchOnReconnect?: MaybeRef<boolean | "always">;
+  /**
+   * If set to `true`, the query will refetch on mount if the data is stale.
+   * If set to `false`, will disable additional instances of a query to trigger background refetches.
+   * If set to `'always'`, the query will always refetch on mount.
+   * Defaults to `true`.
+   */
+  refetchOnMount?: MaybeRef<boolean | "always">;
+  /**
+   * If set to `false`, the query will not be retried on mount if it contains an error.
+   * Defaults to `true`.
+   */
+  retryOnMount?: MaybeRef<boolean>;
+  /**
+   * If set, the component will only re-render if any of the listed properties change.
+   * When set to `['data', 'error']`, the component will only re-render when the `data` or `error` properties change.
+   * When set to `tracked`, access to properties will be tracked, and the component will only re-render when one of the tracked properties change.
+   */
+  notifyOnChangeProps?: Array<keyof InfiniteQueryObserverResult> | "tracked";
+  /**
+   * If set, the component will not re-render if any of the listed properties change.
+   */
+  notifyOnChangePropsExclusions?: Array<keyof InfiniteQueryObserverResult>;
+  /**
+   * This callback will fire any time the query successfully fetches new data or the cache is updated via `setQueryData`.
+   */
+  onSuccess?: (data: TData) => void;
+  /**
+   * This callback will fire if the query encounters an error and will be passed the error.
+   */
+  onError?: (err: TError) => void;
+  /**
+   * This callback will fire any time the query is either successfully fetched or errors and be passed either the data or error.
+   */
+  onSettled?: (data: TData | undefined, error: TError | null) => void;
+  /**
+   * Whether errors should be thrown instead of setting the `error` property.
+   * If set to `true` or `suspense` is `true`, all errors will be thrown to the error boundary.
+   * If set to `false` and `suspense` is `false`, errors are returned as state.
+   * If set to a function, it will be passed the error and should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`).
+   * Defaults to `false`.
+   */
+  useErrorBoundary?: MaybeRef<boolean> | ((error: TError) => boolean);
+  /**
+   * This option can be used to transform or select a part of the data returned by the query function.
+   */
+  select?: (data: TQueryData) => TData;
+  /**
+   * If set to `true`, the query will suspend when `status === 'loading'`
+   * and throw errors when `status === 'error'`.
+   * Defaults to `false`.
+   */
+  suspense?: MaybeRef<boolean>;
+  /**
+   * Set this to `true` to keep the previous `data` when fetching based on a new query key.
+   * Defaults to `false`.
+   */
+  keepPreviousData?: MaybeRef<boolean>;
+  /**
+   * If set, this value will be used as the placeholder data for this particular query observer while the query is still in the `loading` data and no initialData has been provided.
+   */
+  placeholderData?: TQueryData | PlaceholderDataFunction<TQueryData>;
+  /**
+   * If set, the observer will optimistically set the result in fetching state before the query has actually started fetching.
+   * This is to make sure the results are not lagging behind.
+   * Defaults to `true`.
+   */
+  optimisticResults?: MaybeRef<boolean>;
+}

--- a/src/vue/useQuery.ts
+++ b/src/vue/useQuery.ts
@@ -1,6 +1,10 @@
-import { QueryObserver, QueryObserverOptions } from "react-query/core";
+import { QueryObserver } from "react-query/core";
 
-import type { QueryFunction, QueryKey } from "react-query/types/core";
+import type {
+  QueryFunction,
+  QueryKey,
+  QueryObserverOptions,
+} from "react-query/types/core";
 
 import { useBaseQuery, UseQueryReturnType } from "./useBaseQuery";
 import { parseQueryArgs } from "./utils";

--- a/src/vue/useQuery.ts
+++ b/src/vue/useQuery.ts
@@ -1,15 +1,11 @@
-import { QueryObserver } from "react-query/core";
+import { QueryObserver, QueryObserverOptions } from "react-query/core";
 
-import type {
-  QueryFunction,
-  QueryKey,
-  QueryObserverOptions,
-} from "react-query/types/core";
+import type { QueryFunction, QueryKey } from "react-query/types/core";
 
 import { useBaseQuery, UseQueryReturnType } from "./useBaseQuery";
 import { parseQueryArgs } from "./utils";
 
-import type { WithQueryClientKey } from "./types";
+import type { WithQueryClientKey, VueQueryObserverOptions } from "./types";
 
 export type UseQueryOptions<
   TQueryFnData = unknown,
@@ -17,7 +13,7 @@ export type UseQueryOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
 > = WithQueryClientKey<
-  QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>
+  VueQueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>
 >;
 
 export function useQuery<
@@ -53,6 +49,7 @@ export function useQuery<
     "queryKey" | "queryFn"
   >
 ): UseQueryReturnType<TData, TError>;
+
 export function useQuery<
   TQueryFnData,
   TError,

--- a/src/vue/utils.ts
+++ b/src/vue/utils.ts
@@ -7,6 +7,7 @@ import type {
   QueryKey,
   QueryObserverOptions,
 } from "react-query/types/core";
+import { reactive, toRefs } from "vue-demi";
 import { QueryFilters } from "./useIsFetching";
 import { MutationFilters } from "./useIsMutating";
 
@@ -31,18 +32,27 @@ export function parseQueryArgs<
   arg2: QueryFunction<TQueryFnData, TQueryKey> | TOptions = {} as TOptions,
   arg3: TOptions = {} as TOptions
 ): TOptions {
-  if (!isQueryKey(arg1)) {
-    return arg1;
-  }
+  let options: TOptions;
 
-  if (typeof arg2 === "function") {
-    return Object.assign(arg3, {
+  if (!isQueryKey(arg1)) {
+    // `useQuery(optionsObj)`
+    options = reactive(arg1 as unknown as object) as unknown as TOptions;
+  } else if (typeof arg2 === "function") {
+    // `useQuery(queryKey, queryFn, optionsObj?)`
+    options = reactive({
+      ...toRefs(reactive(arg3 as unknown as object)),
       queryKey: arg1,
       queryFn: arg2,
-    });
+    }) as TOptions;
+  } else {
+    // `useQuery(queryKey, optionsObj?)`
+    options = reactive({
+      ...toRefs(reactive(arg2 as unknown as object)),
+      queryKey: arg1,
+    }) as TOptions;
   }
 
-  return Object.assign(arg2, { queryKey: arg1 });
+  return options;
 }
 
 export function parseFilterArgs<TFilters extends QueryFilters>(

--- a/src/vue/utils.ts
+++ b/src/vue/utils.ts
@@ -32,27 +32,27 @@ export function parseQueryArgs<
   arg2: QueryFunction<TQueryFnData, TQueryKey> | TOptions = {} as TOptions,
   arg3: TOptions = {} as TOptions
 ): TOptions {
-  let options: TOptions;
+  let options;
 
   if (!isQueryKey(arg1)) {
     // `useQuery(optionsObj)`
-    options = reactive(arg1 as unknown as object) as unknown as TOptions;
+    options = arg1;
   } else if (typeof arg2 === "function") {
     // `useQuery(queryKey, queryFn, optionsObj?)`
-    options = reactive({
+    options = {
       ...toRefs(reactive(arg3 as unknown as object)),
       queryKey: arg1,
       queryFn: arg2,
-    }) as TOptions;
+    };
   } else {
     // `useQuery(queryKey, optionsObj?)`
-    options = reactive({
+    options = {
       ...toRefs(reactive(arg2 as unknown as object)),
       queryKey: arg1,
-    }) as TOptions;
+    };
   }
 
-  return options;
+  return reactive(options as object) as unknown as TOptions;
 }
 
 export function parseFilterArgs<TFilters extends QueryFilters>(


### PR DESCRIPTION
This PR allows passing individual options as `refs` without an overhead of wrapping the whole options object into `reactive`.

So instead of 
```js
const enabled = computed(...);
useQuery(
  ["book", bookId],
  () => getBook(bookId.value),
  reactive({ enabled })
);
```
we can write 
```js
const enabled = computed(...);
useQuery(
  ["book", bookId],
  () => getBook(bookId.value),
  { enabled }
);
```

I updated docs (with simplified syntax) and added a test