### PR TITLE
Create vue query plugin

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,3 +13,27 @@ yarn add vue-query
 ```
 
 Vue Query is compatible with Vue 2.x + composition API or 3.x
+
+### Vue Query Initialization
+
+Before starting using Vue Query, you need to initialize it.
+
+There are 2 possible ways to do it.
+
+1. [Vue 3 Only] Using `VueQueryPlugin` (recommended)
+
+```js
+import { VueQueryPlugin } from "vue-query";
+
+app.use(VueQueryPlugin);
+```
+
+1. Calling `useQueryProvider` in the root component
+
+```
+<script setup>
+import { useQueryProvider } from 'vue-query';
+
+useQueryProvider();
+</script>
+```

--- a/src/vue/__tests__/vueQueryPlugin.test.ts
+++ b/src/vue/__tests__/vueQueryPlugin.test.ts
@@ -1,0 +1,66 @@
+// import { successMutator, simpleFetcher } from "./test-utils";
+import { QueryClient } from "react-query/types/core";
+import { VueQueryPlugin } from "../vueQueryPlugin";
+import { VUE_QUERY_CLIENT } from "../useQueryClient";
+
+const vue3AppMock = {
+  provide: jest.fn(),
+};
+
+describe("VueQueryPlugin", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when called without additional options", () => {
+    test("should instantiate a client with default clientKey", () => {
+      VueQueryPlugin(vue3AppMock);
+
+      expect(vue3AppMock.provide).toHaveBeenCalledWith(
+        VUE_QUERY_CLIENT,
+        expect.objectContaining({ defaultOptions: {} })
+      );
+    });
+  });
+
+  describe("when called with custom clientKey", () => {
+    test("should instantiate a client with customized clientKey", () => {
+      VueQueryPlugin(vue3AppMock, { queryClientKey: "CUSTOM" });
+
+      expect(vue3AppMock.provide).toHaveBeenCalledWith(
+        VUE_QUERY_CLIENT + "CUSTOM",
+        expect.objectContaining({ defaultOptions: {} })
+      );
+    });
+  });
+
+  describe("when called with custom client", () => {
+    test("should instantiate that custom client", () => {
+      const customClient = { mount: jest.fn() } as unknown as QueryClient;
+      VueQueryPlugin(vue3AppMock, { queryClient: customClient });
+
+      expect(customClient.mount).toHaveBeenCalled();
+      expect(vue3AppMock.provide).toHaveBeenCalledWith(
+        VUE_QUERY_CLIENT,
+        customClient
+      );
+    });
+  });
+
+  describe("when called with custom client condig", () => {
+    test("should instantiate a client with the provided config", () => {
+      VueQueryPlugin(vue3AppMock, {
+        queryClientConfig: {
+          defaultOptions: { queries: { enabled: true } },
+        },
+      });
+
+      expect(vue3AppMock.provide).toHaveBeenCalledWith(
+        VUE_QUERY_CLIENT,
+        expect.objectContaining({
+          defaultOptions: { queries: { enabled: true } },
+        })
+      );
+    });
+  });
+});

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -2,6 +2,7 @@
 
 export { useQueryClient, VUE_QUERY_CLIENT } from "./useQueryClient";
 export { useQueryProvider } from "./useQueryProvider";
+export { VueQueryPlugin } from "./vueQueryPlugin";
 
 export { useQuery } from "./useQuery";
 export { useQueries } from "./useQueries";

--- a/src/vue/vueQueryPlugin.ts
+++ b/src/vue/vueQueryPlugin.ts
@@ -1,0 +1,39 @@
+import { InjectionKey } from "vue-demi";
+import { QueryClient } from "react-query/core";
+import { VUE_QUERY_CLIENT } from "./useQueryClient";
+import { QueryClientConfig } from "./useQueryProvider";
+
+type QueryClientPluginOptions =
+  | {
+      queryClientConfig?: QueryClientConfig;
+      queryClientKey?: string;
+    }
+  | {
+      queryClient?: QueryClient;
+      queryClientKey?: string;
+    };
+
+// Vue 3 only
+interface Vue3App {
+  provide<T>(key: InjectionKey<T> | symbol | string, value: T): this;
+}
+
+export function VueQueryPlugin(
+  app: Vue3App,
+  options: QueryClientPluginOptions = {}
+): void {
+  const clientKeySuffix = options.queryClientKey || "";
+  let client: QueryClient;
+
+  if ("queryClient" in options && options.queryClient) {
+    client = options.queryClient;
+  } else {
+    const clientConfig =
+      "queryClientConfig" in options ? options.queryClientConfig : undefined;
+    client = new QueryClient(clientConfig);
+  }
+
+  client.mount();
+
+  app.provide(VUE_QUERY_CLIENT + clientKeySuffix, client);
+}


### PR DESCRIPTION
## Story
I wanted to use VueQuery in my app's root component:
```ts
useQueryProvider();
useBookQuery(bookId);
```
But I got an error in the console saying that there are no query client available.

After digging into it, I realised that `useQueryProvider` calls Vue's `provide`. Query hooks rely on `inject` which can be used in child components only. That's why I got the error

## Problem
I could work around  - e.g. create a wrapper root component and call `useQueryProvider` there. Or refactor my root component and call query hooks in children components.

But I see also other problems with `useQueryProvider`:
- it's not clear why I should initialize a library using a `useQueryProvider` hook. Should I use it in every component or only in the root component? 
- why "Provider"? "Provider" - is a common term in React community because of React's `Context`. In Vue community "Provider" doesn't really makes any sense.

Vue libraries are usually initialized as plugins.
Take for example Pinia 
![image](https://user-images.githubusercontent.com/427621/150194104-5c04035d-c3e1-4bf9-9a86-42e304c5caf6.png)
 
I think we can do the same thing - initialize Vue Query as a plugin and, thus, make it consistent with other Vue libraries.

It also fits perfectly our case. In 99% cases our users need a global Query Client. We can make it globally available when initializing as a plugin. That would solve my original problem - using VueQuery in the root component.

## Implemented Changes
- created `VueQueryPlugin` (to be used in Vue3 only because plugin api in Vue2 and Vue3 is different)
- added tests
- updated docs - wrote a section on how to init VueQuery

With these changes Vue3 users are able to init VueQuery like this:
![image](https://user-images.githubusercontent.com/427621/150195408-c9b85652-8b4e-4a5c-b04b-91077b837c92.png)

