### PR TITLE
feat: replace useQueryProvider with VueQueryPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,15 @@ For topics not covered in vue-query docs visit https://react-query.tanstack.com/
 
 # Quick Start
 
-1. Attach **Vue Query** to the root component of your Vue application
+1. Initialize **Vue Query** via **VueQueryPlugin**
 
    ```ts
-   import { defineComponent } from "vue";
-   import { useQueryProvider } from "vue-query";
+   import { createApp } from "vue";
+   import { VueQueryPlugin } from "vue-query";
 
-   export default defineComponent({
-     name: "App",
-     setup() {
-       useQueryProvider();
-     },
-   });
+   import App from "./App.vue";
+
+   createApp(App).use(VueQueryPlugin).mount("#app");
    ```
 
 2. Use query
@@ -75,9 +72,7 @@ For topics not covered in vue-query docs visit https://react-query.tanstack.com/
 
    ```ts
    const id = ref(1);
-   const queryKey = ["todos", id];
-   const queryFunction = () => getTodos(id);
    const enabled = ref(false);
 
-   const query = useQuery(queryKey, queryFunction, { enabled });
+   const query = useQuery(["todos", id], () => getTodos(id), { enabled });
    ```

--- a/docs/getting-started/devtools.md
+++ b/docs/getting-started/devtools.md
@@ -6,7 +6,7 @@ When you begin your Vue Query journey, you'll want these DevTools by your side. 
 
 The DevTools are bundle split into the vue-query/devtools package. No need to install anything extra, just:
 
-```
+```ts
 import { VueQueryDevTools } from "vue-query/devtools";
 ```
 
@@ -20,7 +20,7 @@ Floating Mode will mount the DevTools as a fixed, floating element in your app a
 
 Place the following code as high in your Vue app as you can. The closer it is to the root of the page, the better it will work!
 
-```
+```vue
 <script lang="ts">
 import { defineComponent } from "vue";
 import { VueQueryDevTools } from "vue-query/devtools";
@@ -56,7 +56,7 @@ export default defineComponent({
 
 Embedded Mode will embed the DevTools as a regular component in your application. You can style it however you'd like after that!
 
-```
+```vue
 <script lang="ts">
 import { defineComponent } from "vue";
 import { VueQueryDevToolsPanel } from "vue-query/devtools";

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,3 +13,27 @@ yarn add vue-query
 ```
 
 Vue Query is compatible with Vue 2.x + composition API or 3.x
+
+### Vue Query Initialization
+
+Before starting using Vue Query, you need to initialize it.
+
+There are 2 possible ways to do it.
+
+1. [Vue 3 Only] Using `VueQueryPlugin` (recommended)
+
+```js
+import { VueQueryPlugin } from "vue-query";
+
+app.use(VueQueryPlugin);
+```
+
+1. Calling `useQueryProvider` in the root component
+
+```
+<script setup>
+import { useQueryProvider } from 'vue-query';
+
+useQueryProvider();
+</script>
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -20,20 +20,20 @@ Before starting using Vue Query, you need to initialize it.
 
 There are 2 possible ways to do it.
 
-1. [Vue 3 Only] Using `VueQueryPlugin` (recommended)
+1. Using `VueQueryPlugin` (recommended)
 
-```js
-import { VueQueryPlugin } from "vue-query";
+   ```ts
+   import { VueQueryPlugin } from "vue-query";
 
-app.use(VueQueryPlugin);
-```
+   app.use(VueQueryPlugin);
+   ```
 
-1. Calling `useQueryProvider` in the root component
+2. Calling `useQueryProvider` in the root component
 
-```
-<script setup>
-import { useQueryProvider } from 'vue-query';
+   ```vue
+   <script setup>
+   import { useQueryProvider } from 'vue-query';
 
-useQueryProvider();
-</script>
-```
+   useQueryProvider();
+   </script>
+   ```

--- a/docs/guides/custom-clients.md
+++ b/docs/guides/custom-clients.md
@@ -4,32 +4,47 @@ Vue Query allows providing custom `QueryClient` for Vue context.
 
 It might be handy when you need to create `QueryClient` beforehand to integrate it with other libraries that do not have access to the Vue context.
 
-For this reason, `useQueryProvider` accepts either QueryClient options or `QueryClient` as a first argument.
+For this reason, `VueQueryPlugin` accepts either `QueryClientConfig` or `QueryClient` as a plugin options.
 
-If You provide QueryClient options, `QueryClient` instance will be created internally and provided to Vue context.
+If You provide `QueryClientConfig`, `QueryClient` instance will be created internally and provided to Vue context.
 
-```js
-useQueryProvider(queryClientOptions);
+```ts
+const vueQueryPluginOptions: VueQueryPluginOptions = {
+  queryClientConfig: {
+    defaultOptions: { queries: { staleTime: 3600 } },
+  },
+};
+app.use(VueQueryPlugin, vueQueryPluginOptions);
 ```
 
-```js
-const myClient = new QueryClient(queryClientOptions);
-useQueryProvider(myClient);
+```ts
+const myClient = new QueryClient(queryClientConfig);
+const vueQueryPluginOptions: VueQueryPluginOptions = {
+  queryClient: myClient,
+};
+app.use(VueQueryPlugin, vueQueryPluginOptions);
 ```
 
 ### Custom context keys
 
 You can also customize the key under which `QueryClient` will be accessible in Vue context. This can be usefull is you want to avoid name clashing between multiple apps on the same page.
 
-It works both with default, and custom provided `QueryClient`
+It works both with default, and custom `QueryClient`
 
-```js
-useQueryProvider(queryClientOptions, "foo");
+```ts
+const vueQueryPluginOptions: VueQueryPluginOptions = {
+  queryClientKey: "Foo",
+};
+app.use(VueQueryPlugin, vueQueryPluginOptions);
 ```
 
-```js
-const myClient = new QueryClient(queryClientOptions);
-useQueryProvider(myClient, "bar");
+```ts
+const myClient = new QueryClient(queryClientConfig);
+const vueQueryPluginOptions: VueQueryPluginOptions = {
+  queryClient: myClient,
+  queryClientKey: "Foo",
+};
+app.use(VueQueryPlugin, vueQueryPluginOptions);
 ```
 
 To use the custom client key, You have to provide it as a query options
@@ -48,6 +63,9 @@ Devtools also support this by the `queryClientKeys` prop. You can provide multip
 
 Internally custom key will be combined with default query key as a suffix. But user do not have to worry about it.
 
-```js
-useQueryProvider(queryClientOptions, "foo"); // -> VUE_QUERY_CLIENT:foo
+```ts
+const vueQueryPluginOptions: VueQueryPluginOptions = {
+  queryClientKey: "Foo",
+};
+app.use(VueQueryPlugin, vueQueryPluginOptions); // -> VUE_QUERY_CLIENT:Foo
 ```

--- a/docs/guides/window-focus-refetching.md
+++ b/docs/guides/window-focus-refetching.md
@@ -3,21 +3,22 @@ If a user leaves your application and returns to stale data, **Vue Query automat
 ### Disabling globally
 
 ```ts
-import { defineComponent } from "vue";
-import { useQueryProvider } from "vue-query";
+import { createApp } from "vue";
+import { VueQueryPlugin, VueQueryPluginOptions } from "vue-query";
 
-export default defineComponent({
-  name: "App",
-  setup() {
-    useQueryProvider({
-      defaultOptions: {
-        queries: {
-          refetchOnWindowFocus: false,
-        },
+import App from "./App.vue";
+
+const vueQueryPluginOptions: VueQueryPluginOptions = {
+  queryClientConfig: {
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
       },
-    });
+    },
   },
-});
+};
+
+createApp(App).use(VueQueryPlugin, vueQueryPluginOptions).mount("#app");
 ```
 
 ### Disabling Per-Query

--- a/examples/2.x-basic/src/App.vue
+++ b/examples/2.x-basic/src/App.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { defineComponent, ref } from "@vue/composition-api";
-import { useQueryProvider } from "vue-query";
 import { VueQueryDevTools } from "vue-query/devtools";
 
 import Posts from "./Posts.vue";
@@ -10,8 +9,6 @@ export default defineComponent({
   name: "App",
   components: { Posts, Post, VueQueryDevTools },
   setup() {
-    useQueryProvider();
-
     const visitedPosts = ref(new Set());
     const isVisited = (id: number) => visitedPosts.value.has(id);
 

--- a/examples/2.x-basic/src/main.ts
+++ b/examples/2.x-basic/src/main.ts
@@ -1,9 +1,11 @@
 import Vue from "vue";
 import VueCompositionApi, { createApp, h } from "@vue/composition-api";
+import { VueQueryPlugin } from "vue-query";
 
 import App from "./App.vue";
 
 Vue.use(VueCompositionApi);
+Vue.use(VueQueryPlugin);
 
 createApp({
   render() {

--- a/examples/basic/src/App.vue
+++ b/examples/basic/src/App.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { defineComponent, ref } from "vue";
-import { useQueryProvider } from "vue-query";
 import { VueQueryDevTools } from "vue-query/devtools";
 
 import Posts from "./Posts.vue";
@@ -10,8 +9,6 @@ export default defineComponent({
   name: "App",
   components: { Posts, Post, VueQueryDevTools },
   setup() {
-    useQueryProvider();
-
     const visitedPosts = ref(new Set());
     const isVisited = (id: number) => visitedPosts.value.has(id);
 

--- a/examples/basic/src/main.ts
+++ b/examples/basic/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from "vue";
+import { VueQueryPlugin } from "vue-query";
 
 import App from "./App.vue";
 
-createApp(App).mount("#app");
+createApp(App).use(VueQueryPlugin).mount("#app");

--- a/examples/multi-client/src/App.vue
+++ b/examples/multi-client/src/App.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { defineComponent } from "vue";
-import { useQueryProvider, QueryClient } from "vue-query";
 import { VueQueryDevTools } from "vue-query/devtools";
 
 import Todos from "./Todos.vue";
@@ -8,12 +7,6 @@ import Todos from "./Todos.vue";
 export default defineComponent({
   name: "App",
   components: { Todos, VueQueryDevTools },
-  setup() {
-    const myClient = new QueryClient();
-    useQueryProvider();
-    useQueryProvider({}, "Foo");
-    useQueryProvider(myClient, "Bar");
-  },
 });
 </script>
 

--- a/examples/multi-client/src/main.ts
+++ b/examples/multi-client/src/main.ts
@@ -1,5 +1,22 @@
 import { createApp } from "vue";
+import { VueQueryPlugin, VueQueryPluginOptions, QueryClient } from "vue-query";
 
 import App from "./App.vue";
 
-createApp(App).mount("#app");
+const fooClient = new QueryClient();
+const barClient = new QueryClient();
+
+const vueQueryPluginOptions: VueQueryPluginOptions = {
+  additionalClients: [
+    {
+      queryClient: fooClient,
+      queryClientKey: "Foo",
+    },
+    {
+      queryClient: barClient,
+      queryClientKey: "Bar",
+    },
+  ],
+};
+
+createApp(App).use(VueQueryPlugin, vueQueryPluginOptions).mount("#app");

--- a/examples/multi-page/src/App.vue
+++ b/examples/multi-page/src/App.vue
@@ -1,7 +1,5 @@
 <script lang="ts">
 import { defineComponent, ref } from "vue";
-
-import { useQueryProvider } from "vue-query";
 import { VueQueryDevTools } from "vue-query/devtools";
 import Page from "./Page.vue";
 
@@ -9,8 +7,6 @@ export default defineComponent({
   name: "App",
   components: { VueQueryDevTools, Page },
   setup() {
-    useQueryProvider();
-
     const firstPage = ref(1);
 
     const changePage = () => {

--- a/examples/multi-page/src/main.ts
+++ b/examples/multi-page/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from "vue";
+import { VueQueryPlugin } from "vue-query";
 
 import App from "./App.vue";
 
-createApp(App).mount("#app");
+createApp(App).use(VueQueryPlugin).mount("#app");

--- a/examples/simple/src/App.vue
+++ b/examples/simple/src/App.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { defineComponent } from "vue";
-import { useQueryProvider } from "vue-query";
 import { VueQueryDevTools } from "vue-query/devtools";
 
 import Todos from "./Todos.vue";
@@ -8,9 +7,6 @@ import Todos from "./Todos.vue";
 export default defineComponent({
   name: "App",
   components: { Todos, VueQueryDevTools },
-  setup() {
-    useQueryProvider();
-  },
 });
 </script>
 

--- a/examples/simple/src/main.ts
+++ b/examples/simple/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from "vue";
+import { VueQueryPlugin } from "vue-query";
 
 import App from "./App.vue";
 
-createApp(App).mount("#app");
+createApp(App).use(VueQueryPlugin).mount("#app");

--- a/examples/suspense/src/App.vue
+++ b/examples/suspense/src/App.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { defineComponent } from "vue";
-import { useQueryProvider } from "vue-query";
 import { VueQueryDevTools } from "vue-query/devtools";
 
 import Content from "./Content.vue";
@@ -8,9 +7,6 @@ import Content from "./Content.vue";
 export default defineComponent({
   name: "App",
   components: { Content, VueQueryDevTools },
-  setup() {
-    useQueryProvider();
-  },
 });
 </script>
 

--- a/examples/suspense/src/main.ts
+++ b/examples/suspense/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from "vue";
+import { VueQueryPlugin } from "vue-query";
 
 import App from "./App.vue";
 
-createApp(App).mount("#app");
+createApp(App).use(VueQueryPlugin).mount("#app");

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "match-sorter": "^6.3.1",
-        "react-query": "^3.34.8",
+        "react-query": "^3.34.9",
         "vue-demi": "0.10.1"
       },
       "devDependencies": {
@@ -5479,8 +5479,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -5782,6 +5781,18 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -6117,6 +6128,15 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
@@ -7144,6 +7164,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -7151,9 +7184,9 @@
       "dev": true
     },
     "node_modules/react-query": {
-      "version": "3.34.8",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.34.8.tgz",
-      "integrity": "sha512-pl9e2VmVbgKf29Qn/WpmFVtB2g17JPqLLyOQg3GfSs/S2WABvip5xlT464vfXtilLPcJVg9bEHHlqmC38/nvDw==",
+      "version": "3.34.11",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.34.11.tgz",
+      "integrity": "sha512-vRC9J8dklE6rQ1uQHveNgoXOH4ceOn6Ww2+XUYOrEsUaSBZ76aQ/VTzDanXJn+E78lFQn0ajdSomduXP55iCwg==",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "broadcast-channel": "^3.4.1",
@@ -13166,8 +13199,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -13398,6 +13430,15 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -13659,6 +13700,12 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "peer": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -14335,6 +14382,16 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
+    "react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -14342,9 +14399,9 @@
       "dev": true
     },
     "react-query": {
-      "version": "3.34.8",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.34.8.tgz",
-      "integrity": "sha512-pl9e2VmVbgKf29Qn/WpmFVtB2g17JPqLLyOQg3GfSs/S2WABvip5xlT464vfXtilLPcJVg9bEHHlqmC38/nvDw==",
+      "version": "3.34.11",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.34.11.tgz",
+      "integrity": "sha512-vRC9J8dklE6rQ1uQHveNgoXOH4ceOn6Ww2+XUYOrEsUaSBZ76aQ/VTzDanXJn+E78lFQn0ajdSomduXP55iCwg==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "broadcast-channel": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/DamianOsipiuk/vue-query#readme",
   "dependencies": {
     "match-sorter": "^6.3.1",
-    "react-query": "^3.34.8",
+    "react-query": "^3.34.9",
     "vue-demi": "0.10.1"
   },
   "peerDependencies": {

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,12 +1,18 @@
 import resolve from "@rollup/plugin-node-resolve";
-import autoExternal from "rollup-plugin-auto-external";
 import postcss from "rollup-plugin-postcss";
 import typescript from "rollup-plugin-typescript2";
 import vue from "rollup-plugin-vue";
 
 const common = {
-  plugins: [resolve(), autoExternal(), typescript(), vue(), postcss()],
-  external: ["vue-query", "react-query/core", "vue", "vue-demi"],
+  plugins: [resolve(), typescript(), vue(), postcss()],
+  external: [
+    "vue-query",
+    "react-query/core",
+    "vue",
+    "vue-demi",
+    "match-sorter",
+    "@nuxtjs/composition-api",
+  ],
   watch: {
     include: "src/**",
     exclude: ["node_modules/**", "tests"],

--- a/src/nuxt/useNuxtQueryProvider.ts
+++ b/src/nuxt/useNuxtQueryProvider.ts
@@ -1,7 +1,7 @@
 import { useContext } from "@nuxtjs/composition-api";
+import type { QueryClientConfig } from "react-query/types/core";
 
 import { hydrate, useQueryClient, useQueryProvider } from "vue-query";
-import type { QueryClientConfig } from "vue-query";
 
 export function useNuxtQueryProvider(config: QueryClientConfig = {}): void {
   useQueryProvider(config);

--- a/src/vue/__tests__/useQueryClient.test.ts
+++ b/src/vue/__tests__/useQueryClient.test.ts
@@ -1,5 +1,6 @@
 import { getCurrentInstance, inject } from "vue-demi";
-import { useQueryClient, VUE_QUERY_CLIENT } from "../useQueryClient";
+import { useQueryClient } from "../useQueryClient";
+import { VUE_QUERY_CLIENT } from "../utils";
 
 describe("useQueryClient", () => {
   const injectSpy = inject as jest.Mock;

--- a/src/vue/__tests__/useQueryProvider.test.ts
+++ b/src/vue/__tests__/useQueryProvider.test.ts
@@ -1,8 +1,8 @@
 import { provide, onUnmounted } from "vue-demi";
 import { QueryClient } from "react-query/core";
 
-import { VUE_QUERY_CLIENT } from "../useQueryClient";
 import { useQueryProvider } from "../useQueryProvider";
+import { VUE_QUERY_CLIENT } from "../utils";
 
 jest.mock("react-query/core", () => ({
   QueryClient: jest.fn(),

--- a/src/vue/__tests__/vueQueryPlugin.test.ts
+++ b/src/vue/__tests__/vueQueryPlugin.test.ts
@@ -3,7 +3,7 @@ import { isVue2, isVue3 } from "vue-demi";
 import { QueryClient } from "react-query/types/core";
 
 import { VueQueryPlugin } from "../vueQueryPlugin";
-import { VUE_QUERY_CLIENT } from "../useQueryClient";
+import { VUE_QUERY_CLIENT } from "../utils";
 
 interface TestApp extends App {
   onUnmount: Function;

--- a/src/vue/__tests__/vueQueryPlugin.test.ts
+++ b/src/vue/__tests__/vueQueryPlugin.test.ts
@@ -1,0 +1,66 @@
+// import { successMutator, simpleFetcher } from "./test-utils";
+import { QueryClient } from "react-query/types/core";
+import { VueQueryPlugin } from "../vueQueryPlugin";
+import { VUE_QUERY_CLIENT } from "../useQueryClient";
+
+const vue3AppMock = {
+  provide: jest.fn(),
+};
+
+describe("VueQueryPlugin", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when called without additional options", () => {
+    test("should instantiate a client with default clientKey", () => {
+      VueQueryPlugin(vue3AppMock);
+
+      expect(vue3AppMock.provide).toHaveBeenCalledWith(
+        VUE_QUERY_CLIENT,
+        expect.objectContaining({ defaultOptions: {} })
+      );
+    });
+  });
+
+  describe("when called with custom clientKey", () => {
+    test("should instantiate a client with customized clientKey", () => {
+      VueQueryPlugin(vue3AppMock, { queryClientKey: "CUSTOM" });
+
+      expect(vue3AppMock.provide).toHaveBeenCalledWith(
+        VUE_QUERY_CLIENT + "CUSTOM",
+        expect.objectContaining({ defaultOptions: {} })
+      );
+    });
+  });
+
+  describe("when called with custom client", () => {
+    test("should instantiate that custom client", () => {
+      const customClient = { mount: jest.fn() } as unknown as QueryClient;
+      VueQueryPlugin(vue3AppMock, { queryClient: customClient });
+
+      expect(customClient.mount).toHaveBeenCalled();
+      expect(vue3AppMock.provide).toHaveBeenCalledWith(
+        VUE_QUERY_CLIENT,
+        customClient
+      );
+    });
+  });
+
+  describe("when called with custom client condig", () => {
+    test("should instantiate a client with the provided config", () => {
+      VueQueryPlugin(vue3AppMock, {
+        queryClientConfig: {
+          defaultOptions: { queries: { enabled: true } },
+        },
+      });
+
+      expect(vue3AppMock.provide).toHaveBeenCalledWith(
+        VUE_QUERY_CLIENT,
+        expect.objectContaining({
+          defaultOptions: { queries: { enabled: true } },
+        })
+      );
+    });
+  });
+});

--- a/src/vue/__tests__/vueQueryPlugin.test.ts
+++ b/src/vue/__tests__/vueQueryPlugin.test.ts
@@ -113,7 +113,7 @@ describe("VueQueryPlugin", () => {
       appMock._mixin.beforeCreate?.call(appMock);
 
       expect(appMock._provided).toMatchObject({
-        [VUE_QUERY_CLIENT + "CUSTOM"]: expect.objectContaining({
+        [VUE_QUERY_CLIENT + ":CUSTOM"]: expect.objectContaining({
           defaultOptions: {},
         }),
       });
@@ -124,7 +124,7 @@ describe("VueQueryPlugin", () => {
       VueQueryPlugin.install?.(appMock, { queryClientKey: "CUSTOM" });
 
       expect(appMock.provide).toHaveBeenCalledWith(
-        VUE_QUERY_CLIENT + "CUSTOM",
+        VUE_QUERY_CLIENT + ":CUSTOM",
         expect.objectContaining({ defaultOptions: {} })
       );
     });
@@ -230,8 +230,8 @@ describe("VueQueryPlugin", () => {
         expect(barClient.mount).toHaveBeenCalled();
         expect(appMock._provided).toMatchObject({
           VUE_QUERY_CLIENT: expect.anything(),
-          [VUE_QUERY_CLIENT + foo]: fooClient,
-          [VUE_QUERY_CLIENT + bar]: barClient,
+          [`${VUE_QUERY_CLIENT}:${foo}`]: fooClient,
+          [`${VUE_QUERY_CLIENT}:${bar}`]: barClient,
         });
       }
     );
@@ -272,12 +272,12 @@ describe("VueQueryPlugin", () => {
         );
         expect(appMock.provide).toHaveBeenNthCalledWith(
           2,
-          VUE_QUERY_CLIENT + foo,
+          `${VUE_QUERY_CLIENT}:${foo}`,
           fooClient
         );
         expect(appMock.provide).toHaveBeenNthCalledWith(
           3,
-          VUE_QUERY_CLIENT + bar,
+          `${VUE_QUERY_CLIENT}:${bar}`,
           barClient
         );
       }

--- a/src/vue/__tests__/vueQueryPlugin.test.ts
+++ b/src/vue/__tests__/vueQueryPlugin.test.ts
@@ -1,70 +1,180 @@
-// import { QueryClient } from "react-query/types/core";
-// import { VueQueryPlugin } from "../vueQueryPlugin";
-// import { VUE_QUERY_CLIENT } from "../useQueryClient";
-// import { App } from "vue-demi";
+import { App, ComponentOptions } from "vue";
+import { isVue2, isVue3 } from "vue-demi";
+import { QueryClient } from "react-query/types/core";
 
-// const appMock = {
-//   provide: jest.fn(),
-// } as unknown as App;
+import { VueQueryPlugin } from "../vueQueryPlugin";
+import { VUE_QUERY_CLIENT } from "../useQueryClient";
+
+interface TestApp extends App {
+  onUnmount: Function;
+  _mixin: ComponentOptions;
+  _provided: Record<string, any>;
+}
+
+const testIf = (condition: boolean) => (condition ? test : test.skip);
+
+function getAppMock(withUnmountHook = false): TestApp {
+  const mock = {
+    provide: jest.fn(),
+    unmount: jest.fn(),
+    onUnmount: withUnmountHook ? jest.fn() : undefined,
+    mixin: (m: ComponentOptions): any => {
+      mock._mixin = m;
+    },
+  } as unknown as TestApp;
+
+  return mock;
+}
 
 describe("VueQueryPlugin", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  test("todo", () => {
-    expect(true).toBe(true);
+  describe("when called without additional options", () => {
+    testIf(isVue2)("should provide a client with default clientKey", () => {
+      const appMock = getAppMock();
+      VueQueryPlugin.install?.(appMock);
+
+      appMock._mixin.beforeCreate?.call(appMock);
+
+      expect(appMock._provided).toMatchObject({
+        VUE_QUERY_CLIENT: expect.objectContaining({ defaultOptions: {} }),
+      });
+    });
+
+    testIf(isVue3)("should provide a client with default clientKey", () => {
+      const appMock = getAppMock();
+      VueQueryPlugin.install?.(appMock);
+
+      expect(appMock.provide).toHaveBeenCalledWith(
+        VUE_QUERY_CLIENT,
+        expect.objectContaining({ defaultOptions: {} })
+      );
+    });
   });
 
-  // describe("when called without additional options", () => {
-  //   test("should instantiate a client with default clientKey", () => {
-  //     VueQueryPlugin.install(appMock);
+  describe("when called with custom clientKey", () => {
+    testIf(isVue2)("should provide a client with customized clientKey", () => {
+      const appMock = getAppMock();
+      VueQueryPlugin.install?.(appMock, { queryClientKey: "CUSTOM" });
 
-  //     expect(appMock.provide).toHaveBeenCalledWith(
-  //       VUE_QUERY_CLIENT,
-  //       expect.objectContaining({ defaultOptions: {} })
-  //     );
-  //   });
-  // });
+      appMock._mixin.beforeCreate?.call(appMock);
 
-  // describe("when called with custom clientKey", () => {
-  //   test("should instantiate a client with customized clientKey", () => {
-  //     VueQueryPlugin.install(appMock, { queryClientKey: "CUSTOM" });
+      expect(appMock._provided).toMatchObject({
+        [VUE_QUERY_CLIENT + "CUSTOM"]: expect.objectContaining({
+          defaultOptions: {},
+        }),
+      });
+    });
 
-  //     expect(appMock.provide).toHaveBeenCalledWith(
-  //       VUE_QUERY_CLIENT + "CUSTOM",
-  //       expect.objectContaining({ defaultOptions: {} })
-  //     );
-  //   });
-  // });
+    testIf(isVue3)("should provide a client with customized clientKey", () => {
+      const appMock = getAppMock();
+      VueQueryPlugin.install?.(appMock, { queryClientKey: "CUSTOM" });
 
-  // describe("when called with custom client", () => {
-  //   test("should instantiate that custom client", () => {
-  //     const customClient = { mount: jest.fn() } as unknown as QueryClient;
-  //     VueQueryPlugin.install(appMock, { queryClient: customClient });
+      expect(appMock.provide).toHaveBeenCalledWith(
+        VUE_QUERY_CLIENT + "CUSTOM",
+        expect.objectContaining({ defaultOptions: {} })
+      );
+    });
+  });
 
-  //     expect(customClient.mount).toHaveBeenCalled();
-  //     expect(appMock.provide).toHaveBeenCalledWith(
-  //       VUE_QUERY_CLIENT,
-  //       customClient
-  //     );
-  //   });
-  // });
+  describe("when called with custom client", () => {
+    testIf(isVue2)("should provide that custom client", () => {
+      const appMock = getAppMock();
+      const customClient = { mount: jest.fn() } as unknown as QueryClient;
+      VueQueryPlugin.install?.(appMock, { queryClient: customClient });
 
-  // describe("when called with custom client condig", () => {
-  //   test("should instantiate a client with the provided config", () => {
-  //     VueQueryPlugin.install(appMock, {
-  //       queryClientConfig: {
-  //         defaultOptions: { queries: { enabled: true } },
-  //       },
-  //     });
+      appMock._mixin.beforeCreate?.call(appMock);
 
-  //     expect(appMock.provide).toHaveBeenCalledWith(
-  //       VUE_QUERY_CLIENT,
-  //       expect.objectContaining({
-  //         defaultOptions: { queries: { enabled: true } },
-  //       })
-  //     );
-  //   });
-  // });
+      expect(customClient.mount).toHaveBeenCalled();
+      expect(appMock._provided).toMatchObject({
+        VUE_QUERY_CLIENT: customClient,
+      });
+    });
+
+    testIf(isVue3)("should provide that custom client", () => {
+      const appMock = getAppMock();
+      const customClient = { mount: jest.fn() } as unknown as QueryClient;
+      VueQueryPlugin.install?.(appMock, { queryClient: customClient });
+
+      expect(customClient.mount).toHaveBeenCalled();
+      expect(appMock.provide).toHaveBeenCalledWith(
+        VUE_QUERY_CLIENT,
+        customClient
+      );
+    });
+  });
+
+  describe("when called with custom client condig", () => {
+    testIf(isVue2)(
+      "should instantiate a client with the provided config",
+      () => {
+        const appMock = getAppMock();
+        const config = {
+          defaultOptions: { queries: { enabled: true } },
+        };
+        VueQueryPlugin.install?.(appMock, {
+          queryClientConfig: config,
+        });
+
+        appMock._mixin.beforeCreate?.call(appMock);
+
+        expect(appMock._provided).toMatchObject({
+          VUE_QUERY_CLIENT: expect.objectContaining(config),
+        });
+      }
+    );
+
+    testIf(isVue3)(
+      "should instantiate a client with the provided config",
+      () => {
+        const appMock = getAppMock();
+        const config = {
+          defaultOptions: { queries: { enabled: true } },
+        };
+        VueQueryPlugin.install?.(appMock, {
+          queryClientConfig: config,
+        });
+
+        expect(appMock.provide).toHaveBeenCalledWith(
+          VUE_QUERY_CLIENT,
+          expect.objectContaining(config)
+        );
+      }
+    );
+  });
+
+  describe("when app unmounts", () => {
+    test("should wrap unmount if onUnmount is missing", () => {
+      const appMock = getAppMock();
+      const customClient = {
+        mount: jest.fn(),
+        unmount: jest.fn(),
+      } as unknown as QueryClient;
+      const originalUnmount = appMock.unmount;
+      VueQueryPlugin.install?.(appMock, { queryClient: customClient });
+
+      appMock.unmount();
+
+      expect(appMock.unmount).not.toEqual(originalUnmount);
+      expect(customClient.unmount).toHaveBeenCalledTimes(1);
+      expect(originalUnmount).toHaveBeenCalledTimes(1);
+    });
+
+    test("should call onUnmount if present", () => {
+      const appMock = getAppMock(true);
+      const customClient = {
+        mount: jest.fn(),
+        unmount: jest.fn(),
+      } as unknown as QueryClient;
+      const originalUnmount = appMock.unmount;
+      VueQueryPlugin.install?.(appMock, { queryClient: customClient });
+
+      appMock.unmount();
+
+      expect(appMock.unmount).toEqual(originalUnmount);
+      expect(appMock.onUnmount).toHaveBeenCalledWith(customClient.unmount);
+    });
+  });
 });

--- a/src/vue/__tests__/vueQueryPlugin.test.ts
+++ b/src/vue/__tests__/vueQueryPlugin.test.ts
@@ -1,66 +1,70 @@
-// import { successMutator, simpleFetcher } from "./test-utils";
-import { QueryClient } from "react-query/types/core";
-import { VueQueryPlugin } from "../vueQueryPlugin";
-import { VUE_QUERY_CLIENT } from "../useQueryClient";
+// import { QueryClient } from "react-query/types/core";
+// import { VueQueryPlugin } from "../vueQueryPlugin";
+// import { VUE_QUERY_CLIENT } from "../useQueryClient";
+// import { App } from "vue-demi";
 
-const vue3AppMock = {
-  provide: jest.fn(),
-};
+// const appMock = {
+//   provide: jest.fn(),
+// } as unknown as App;
 
 describe("VueQueryPlugin", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe("when called without additional options", () => {
-    test("should instantiate a client with default clientKey", () => {
-      VueQueryPlugin(vue3AppMock);
-
-      expect(vue3AppMock.provide).toHaveBeenCalledWith(
-        VUE_QUERY_CLIENT,
-        expect.objectContaining({ defaultOptions: {} })
-      );
-    });
+  test("todo", () => {
+    expect(true).toBe(true);
   });
 
-  describe("when called with custom clientKey", () => {
-    test("should instantiate a client with customized clientKey", () => {
-      VueQueryPlugin(vue3AppMock, { queryClientKey: "CUSTOM" });
+  // describe("when called without additional options", () => {
+  //   test("should instantiate a client with default clientKey", () => {
+  //     VueQueryPlugin.install(appMock);
 
-      expect(vue3AppMock.provide).toHaveBeenCalledWith(
-        VUE_QUERY_CLIENT + "CUSTOM",
-        expect.objectContaining({ defaultOptions: {} })
-      );
-    });
-  });
+  //     expect(appMock.provide).toHaveBeenCalledWith(
+  //       VUE_QUERY_CLIENT,
+  //       expect.objectContaining({ defaultOptions: {} })
+  //     );
+  //   });
+  // });
 
-  describe("when called with custom client", () => {
-    test("should instantiate that custom client", () => {
-      const customClient = { mount: jest.fn() } as unknown as QueryClient;
-      VueQueryPlugin(vue3AppMock, { queryClient: customClient });
+  // describe("when called with custom clientKey", () => {
+  //   test("should instantiate a client with customized clientKey", () => {
+  //     VueQueryPlugin.install(appMock, { queryClientKey: "CUSTOM" });
 
-      expect(customClient.mount).toHaveBeenCalled();
-      expect(vue3AppMock.provide).toHaveBeenCalledWith(
-        VUE_QUERY_CLIENT,
-        customClient
-      );
-    });
-  });
+  //     expect(appMock.provide).toHaveBeenCalledWith(
+  //       VUE_QUERY_CLIENT + "CUSTOM",
+  //       expect.objectContaining({ defaultOptions: {} })
+  //     );
+  //   });
+  // });
 
-  describe("when called with custom client condig", () => {
-    test("should instantiate a client with the provided config", () => {
-      VueQueryPlugin(vue3AppMock, {
-        queryClientConfig: {
-          defaultOptions: { queries: { enabled: true } },
-        },
-      });
+  // describe("when called with custom client", () => {
+  //   test("should instantiate that custom client", () => {
+  //     const customClient = { mount: jest.fn() } as unknown as QueryClient;
+  //     VueQueryPlugin.install(appMock, { queryClient: customClient });
 
-      expect(vue3AppMock.provide).toHaveBeenCalledWith(
-        VUE_QUERY_CLIENT,
-        expect.objectContaining({
-          defaultOptions: { queries: { enabled: true } },
-        })
-      );
-    });
-  });
+  //     expect(customClient.mount).toHaveBeenCalled();
+  //     expect(appMock.provide).toHaveBeenCalledWith(
+  //       VUE_QUERY_CLIENT,
+  //       customClient
+  //     );
+  //   });
+  // });
+
+  // describe("when called with custom client condig", () => {
+  //   test("should instantiate a client with the provided config", () => {
+  //     VueQueryPlugin.install(appMock, {
+  //       queryClientConfig: {
+  //         defaultOptions: { queries: { enabled: true } },
+  //       },
+  //     });
+
+  //     expect(appMock.provide).toHaveBeenCalledWith(
+  //       VUE_QUERY_CLIENT,
+  //       expect.objectContaining({
+  //         defaultOptions: { queries: { enabled: true } },
+  //       })
+  //     );
+  //   });
+  // });
 });

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 
-export { useQueryClient, VUE_QUERY_CLIENT } from "./useQueryClient";
+export { useQueryClient } from "./useQueryClient";
 export { useQueryProvider } from "./useQueryProvider";
 export { VueQueryPlugin } from "./vueQueryPlugin";
 
@@ -11,6 +11,7 @@ export { useMutation } from "./useMutation";
 export { useIsFetching } from "./useIsFetching";
 export { useIsMutating } from "./useIsMutating";
 export {
+  VUE_QUERY_CLIENT,
   parseFilterArgs,
   parseMutationArgs,
   parseQueryArgs,

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -2,6 +2,7 @@
 
 export { useQueryClient, VUE_QUERY_CLIENT } from "./useQueryClient";
 export { useQueryProvider } from "./useQueryProvider";
+export { VueQueryPlugin } from "./vueQueryPlugin";
 
 export { useQuery } from "./useQuery";
 export { useQueries } from "./useQueries";

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -17,7 +17,6 @@ export {
   parseMutationFilterArgs,
 } from "./utils";
 
-export type { QueryClientConfig } from "./useQueryProvider";
 export type { UseQueryReturnType } from "./useBaseQuery";
 export type { UseQueryOptions } from "./useQuery";
 export type { UseInfiniteQueryOptions } from "./useInfiniteQuery";
@@ -25,3 +24,4 @@ export type { UseMutationOptions, UseMutationReturnType } from "./useMutation";
 export type { UseQueriesOptions, UseQueriesResults } from "./useQueries";
 export type { MutationFilters } from "./useIsMutating";
 export type { QueryFilters } from "./useIsFetching";
+export type { VueQueryPluginOptions } from "./vueQueryPlugin";

--- a/src/vue/useQueryClient.ts
+++ b/src/vue/useQueryClient.ts
@@ -1,8 +1,7 @@
 import { getCurrentInstance, inject } from "vue-demi";
 
 import type { QueryClient } from "react-query/types/core";
-
-export const VUE_QUERY_CLIENT = "VUE_QUERY_CLIENT";
+import { getClientKey } from "./utils";
 
 export function useQueryClient(id = ""): QueryClient {
   const vm = getCurrentInstance()?.proxy;
@@ -13,8 +12,8 @@ export function useQueryClient(id = ""): QueryClient {
     );
   }
 
-  const suffix = id ? `:${id}` : "";
-  const queryClient = inject<QueryClient>(VUE_QUERY_CLIENT + suffix);
+  const key = getClientKey(id);
+  const queryClient = inject<QueryClient>(key);
 
   if (!queryClient) {
     throw new Error(

--- a/src/vue/useQueryClient.ts
+++ b/src/vue/useQueryClient.ts
@@ -18,7 +18,7 @@ export function useQueryClient(id = ""): QueryClient {
 
   if (!queryClient) {
     throw new Error(
-      "No queryClient found in Vue context, use 'useQueryProvider' to set one in the root component."
+      "No 'queryClient' found in Vue context, use 'VueQueryPlugin' to properly initialize the library."
     );
   }
 

--- a/src/vue/useQueryProvider.ts
+++ b/src/vue/useQueryProvider.ts
@@ -1,19 +1,18 @@
 import { provide, onUnmounted } from "vue-demi";
 import { QueryClient } from "react-query/core";
 import type { QueryClientConfig } from "react-query/types/core";
-
-import { VUE_QUERY_CLIENT } from "./useQueryClient";
+import { getClientKey } from "./utils";
 
 export function useQueryProvider(
   arg1: QueryClientConfig | QueryClient = {},
   id = ""
 ): void {
-  const suffix = id ? `:${id}` : "";
   const client = arg1 instanceof QueryClient ? arg1 : new QueryClient(arg1);
 
   client.mount();
 
-  provide(VUE_QUERY_CLIENT + suffix, client);
+  const key = getClientKey(id);
+  provide(key, client);
 
   onUnmounted(() => {
     client.unmount();

--- a/src/vue/useQueryProvider.ts
+++ b/src/vue/useQueryProvider.ts
@@ -1,12 +1,8 @@
 import { provide, onUnmounted } from "vue-demi";
 import { QueryClient } from "react-query/core";
+import type { QueryClientConfig } from "react-query/types/core";
 
 import { VUE_QUERY_CLIENT } from "./useQueryClient";
-
-// QueryClientConfig isn't exported so we need to extract it
-export type QueryClientConfig = NonNullable<
-  ConstructorParameters<typeof QueryClient>[0]
->;
 
 export function useQueryProvider(
   arg1: QueryClientConfig | QueryClient = {},

--- a/src/vue/utils.ts
+++ b/src/vue/utils.ts
@@ -11,6 +11,13 @@ import { isRef, reactive, toRefs, unref, UnwrapRef } from "vue-demi";
 import { QueryFilters } from "./useIsFetching";
 import { MutationFilters } from "./useIsMutating";
 
+export const VUE_QUERY_CLIENT = "VUE_QUERY_CLIENT";
+
+export function getClientKey(key?: string) {
+  const suffix = key ? `:${key}` : "";
+  return `${VUE_QUERY_CLIENT}${suffix}`;
+}
+
 export function isQueryKey(value: unknown): value is QueryKey {
   return typeof value === "string" || Array.isArray(value);
 }

--- a/src/vue/vueQueryPlugin.ts
+++ b/src/vue/vueQueryPlugin.ts
@@ -1,0 +1,39 @@
+import { InjectionKey } from "vue-demi";
+import { QueryClient } from "react-query/core";
+import { VUE_QUERY_CLIENT } from "./useQueryClient";
+import { QueryClientConfig } from "./useQueryProvider";
+
+type QueryClientPluginOptions =
+  | {
+      queryClientConfig?: QueryClientConfig;
+      queryClientKey?: string;
+    }
+  | {
+      queryClient?: QueryClient;
+      queryClientKey?: string;
+    };
+
+// Vue 3 only
+interface Vue3App {
+  provide<T>(key: InjectionKey<T> | symbol | string, value: T): this;
+}
+
+export function VueQueryPlugin(
+  app: Vue3App,
+  options: QueryClientPluginOptions = {}
+): void {
+  const clientKeySuffix = options.queryClientKey || "";
+  let client: QueryClient;
+
+  if ("queryClient" in options && options.queryClient) {
+    client = options.queryClient;
+  } else {
+    const clientConfig =
+      "queryClientConfig" in options ? options.queryClientConfig : undefined;
+    client = new QueryClient(clientConfig);
+  }
+
+  client.mount();
+
+  app.provide(VUE_QUERY_CLIENT + clientKeySuffix, client);
+}

--- a/src/vue/vueQueryPlugin.ts
+++ b/src/vue/vueQueryPlugin.ts
@@ -1,7 +1,8 @@
 import { isVue2 } from "vue-demi";
 import { QueryClient } from "react-query/core";
 import { VUE_QUERY_CLIENT } from "./useQueryClient";
-import { QueryClientConfig } from "./useQueryProvider";
+
+import { QueryClientConfig } from "react-query/types/core";
 
 import type { Plugin } from "vue";
 
@@ -15,7 +16,7 @@ interface ClientOptions {
   queryClientKey?: string;
 }
 
-type VueQueryPluginOptions = ConfigOptions | ClientOptions;
+export type VueQueryPluginOptions = ConfigOptions | ClientOptions;
 
 export const VueQueryPlugin: Plugin = {
   install: (app, options: VueQueryPluginOptions = {}) => {

--- a/src/vue/vueQueryPlugin.ts
+++ b/src/vue/vueQueryPlugin.ts
@@ -1,39 +1,53 @@
-import { InjectionKey } from "vue-demi";
+import { isVue2 } from "vue-demi";
 import { QueryClient } from "react-query/core";
 import { VUE_QUERY_CLIENT } from "./useQueryClient";
 import { QueryClientConfig } from "./useQueryProvider";
 
-type QueryClientPluginOptions =
-  | {
-      queryClientConfig?: QueryClientConfig;
-      queryClientKey?: string;
+import type { Plugin } from "vue";
+
+interface ConfigOptions {
+  queryClientConfig?: QueryClientConfig;
+  queryClientKey?: string;
+}
+
+interface ClientOptions {
+  queryClient?: QueryClient;
+  queryClientKey?: string;
+}
+
+type VueQueryPluginOptions = ConfigOptions | ClientOptions;
+
+export const VueQueryPlugin: Plugin = {
+  install: (app, options: VueQueryPluginOptions = {}) => {
+    const clientKeySuffix = options.queryClientKey || "";
+    let client: QueryClient;
+
+    if ("queryClient" in options && options.queryClient) {
+      client = options.queryClient;
+    } else {
+      const clientConfig =
+        "queryClientConfig" in options ? options.queryClientConfig : undefined;
+      client = new QueryClient(clientConfig);
     }
-  | {
-      queryClient?: QueryClient;
-      queryClientKey?: string;
-    };
 
-// Vue 3 only
-interface Vue3App {
-  provide<T>(key: InjectionKey<T> | symbol | string, value: T): this;
-}
+    client.mount();
 
-export function VueQueryPlugin(
-  app: Vue3App,
-  options: QueryClientPluginOptions = {}
-): void {
-  const clientKeySuffix = options.queryClientKey || "";
-  let client: QueryClient;
-
-  if ("queryClient" in options && options.queryClient) {
-    client = options.queryClient;
-  } else {
-    const clientConfig =
-      "queryClientConfig" in options ? options.queryClientConfig : undefined;
-    client = new QueryClient(clientConfig);
-  }
-
-  client.mount();
-
-  app.provide(VUE_QUERY_CLIENT + clientKeySuffix, client);
-}
+    if (isVue2) {
+      app.mixin({
+        beforeCreate() {
+          // HACK: taken from provide(): https://github.com/vuejs/composition-api/blob/master/src/apis/inject.ts#L30
+          if (!this._provided) {
+            const provideCache = {};
+            Object.defineProperty(this, "_provided", {
+              get: () => provideCache,
+              set: (v) => Object.assign(provideCache, v),
+            });
+          }
+          this._provided[VUE_QUERY_CLIENT + clientKeySuffix] = client;
+        },
+      });
+    } else {
+      app.provide(VUE_QUERY_CLIENT + clientKeySuffix, client);
+    }
+  },
+};

--- a/src/vue/vueQueryPlugin.ts
+++ b/src/vue/vueQueryPlugin.ts
@@ -32,6 +32,19 @@ export const VueQueryPlugin: Plugin = {
 
     client.mount();
 
+    // @ts-expect-error onUnmount is not released yet
+    if (app.onUnmount) {
+      // @ts-expect-error onUnmount is not released yet
+      app.onUnmount(client.unmount);
+    } else {
+      const originalUnmount = app.unmount;
+      app.unmount = function vueQueryUnmount() {
+        client.unmount();
+        originalUnmount();
+      };
+    }
+
+    /* istanbul ignore next */
     if (isVue2) {
       app.mixin({
         beforeCreate() {

--- a/src/vue/vueQueryPlugin.ts
+++ b/src/vue/vueQueryPlugin.ts
@@ -27,7 +27,9 @@ export type VueQueryPluginOptions = ConfigOptions | ClientOptions;
 
 export const VueQueryPlugin: Plugin = {
   install: (app, options: VueQueryPluginOptions = {}) => {
-    const clientKeySuffix = options.queryClientKey || "";
+    const clientKeySuffix = options.queryClientKey
+      ? `:${options.queryClientKey}`
+      : "";
     let client: QueryClient;
 
     if ("queryClient" in options && options.queryClient) {
@@ -74,8 +76,9 @@ export const VueQueryPlugin: Plugin = {
           this._provided[VUE_QUERY_CLIENT + clientKeySuffix] = client;
 
           options.additionalClients?.forEach((additionalClient) => {
-            this._provided[VUE_QUERY_CLIENT + additionalClient.queryClientKey] =
-              additionalClient.queryClient;
+            this._provided[
+              `${VUE_QUERY_CLIENT}:${additionalClient.queryClientKey}`
+            ] = additionalClient.queryClient;
             additionalClient.queryClient.mount();
           });
         },
@@ -85,7 +88,7 @@ export const VueQueryPlugin: Plugin = {
 
       options.additionalClients?.forEach((additionalClient) => {
         app.provide(
-          VUE_QUERY_CLIENT + additionalClient.queryClientKey,
+          `${VUE_QUERY_CLIENT}:${additionalClient.queryClientKey}`,
           additionalClient.queryClient
         );
         additionalClient.queryClient.mount();


### PR DESCRIPTION
TODO:
- [x] Vue2 support
- [x] cleanup on unmount
- [x] multiple clients support
- [x] docs change to use plugin instead of provider

Closes: https://github.com/DamianOsipiuk/vue-query/issues/98
Closes: https://github.com/DamianOsipiuk/vue-query/pull/112