### PR TITLE
Revise docs

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -5,16 +5,6 @@
   - [DevTools](getting-started/devtools.md)
   - [TypeScript](getting-started/typescript.md)
 
-- Examples
-
-  - [Simple](examples/simple.md)
-  - [Basic](examples/basic.md)
-  - [Multi Page](examples/multi-page.md)
-  - [Suspense (experimental)](examples/suspense.md)
-  - [Vue 2.x (experimental)](examples/vue-2.x.md)
-  - [Nuxt.js (experimental)](examples/nuxt.md)
-  - [Vite SSR (experimental)](examples/vite-ssr.md)
-
 - Guides & Concepts
 
   - [Important Defaults](guides/important-defaults.md)
@@ -35,3 +25,13 @@
   - [Mutations](guides/mutations.md)
   - [Custom clients (experimental)](guides/custom-clients.md)
   - [SSR & Nuxt.js (experimental)](guides/ssr.md)
+
+- Examples
+
+  - [Simple](examples/simple.md)
+  - [Basic](examples/basic.md)
+  - [Multi Page](examples/multi-page.md)
+  - [Suspense (experimental)](examples/suspense.md)
+  - [Vue 2.x (experimental)](examples/vue-2.x.md)
+  - [Nuxt.js (experimental)](examples/nuxt.md)
+  - [Vite SSR (experimental)](examples/vite-ssr.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -25,6 +25,7 @@
   - [Mutations](guides/mutations.md)
   - [Custom clients (experimental)](guides/custom-clients.md)
   - [SSR & Nuxt.js (experimental)](guides/ssr.md)
+  - [Best Practices](guides/best-practices.md)
 
 - Examples
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -32,8 +32,38 @@ There are 2 possible ways to do it.
 
    ```vue
    <script setup>
-   import { useQueryProvider } from 'vue-query';
+   import { useQueryProvider } from "vue-query";
 
    useQueryProvider();
    </script>
    ```
+
+### Use of Composition API with `<script setup>`
+
+All examples in our documentation use [`<script setup>`](https://staging.vuejs.org/api/sfc-script-setup.html) syntax.
+
+Vue 2 users can also use that syntax using [this plugin](https://github.com/antfu/unplugin-vue2-script-setup). Please check the plugin documentation for installation details.
+
+If you are not a fan of `<script setup>` syntax, you can easily translate all the examples into normal Composition API syntax by moving the code under `setup()()` function and returning the values used in the template.
+
+```vue
+<script>
+import { defineComponent } from "vue";
+import { useQuery } from "vue-query";
+
+function useTodosQuery() {
+  return useQuery("todos", fetchTodoList);
+}
+
+export default defineComponent({
+  name: "Todos",
+  setup(props) {
+    const { isLoading, isError, data, error, isFetching } = useTodosQuery();
+
+    return { isLoading, isError, data, error, isFetching };
+  },
+});
+</script>
+
+<template>...</template>
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -44,7 +44,7 @@ All examples in our documentation use [`<script setup>`](https://staging.vuejs.o
 
 Vue 2 users can also use that syntax using [this plugin](https://github.com/antfu/unplugin-vue2-script-setup). Please check the plugin documentation for installation details.
 
-If you are not a fan of `<script setup>` syntax, you can easily translate all the examples into normal Composition API syntax by moving the code under `setup()()` function and returning the values used in the template.
+If you are not a fan of `<script setup>` syntax, you can easily translate all the examples into normal Composition API syntax by moving the code under `setup()` function and returning the values used in the template.
 
 ```vue
 <script>

--- a/docs/guides/background-fetching-indicators.md
+++ b/docs/guides/background-fetching-indicators.md
@@ -2,8 +2,6 @@ A query's `status === 'loading'` state is sufficient enough to show the initial 
 
 To do this, queries also supply you with an `isFetching` boolean that you can use to show that it's in a fetching state, regardless of the state of the `status` variable:
 
-?> The example below uses `<script setup>` syntax.
-
 ```vue
 <script setup>
 import { useQuery } from "vue-query";
@@ -30,8 +28,6 @@ const { isLoading, isError, data, error, isFetching } = useTodosQuery();
 ### Displaying Global Background Fetching Loading State
 
 In addition to individual query loading states, if you would like to show a global loading indicator when **any** queries are fetching (including in the background), you can use the `useIsFetching` hook:
-
-?> The example below uses `<script setup>` syntax.
 
 ```vue
 <script setup>

--- a/docs/guides/background-fetching-indicators.md
+++ b/docs/guides/background-fetching-indicators.md
@@ -2,21 +2,17 @@ A query's `status === 'loading'` state is sufficient enough to show the initial 
 
 To do this, queries also supply you with an `isFetching` boolean that you can use to show that it's in a fetching state, regardless of the state of the `status` variable:
 
+?> The example below uses `<script setup>` syntax.
+
 ```vue
-<script>
-import { defineComponent } from "vue";
+<script setup>
 import { useQuery } from "vue-query";
 
-export default defineComponent({
-  name: "Todo",
-  setup(props) {
-    const { isLoading, isError, data, error, isFetching } = useQuery(
-      "todos",
-      fetchTodoList
-    );
-    return { isLoading, isError, data, error, isFetching };
-  },
-});
+function useTodosQuery() {
+  return useQuery("todos", fetchTodoList);
+}
+
+const { isLoading, isError, data, error, isFetching } = useTodosQuery();
 </script>
 
 <template>
@@ -35,17 +31,13 @@ export default defineComponent({
 
 In addition to individual query loading states, if you would like to show a global loading indicator when **any** queries are fetching (including in the background), you can use the `useIsFetching` hook:
 
+?> The example below uses `<script setup>` syntax.
+
 ```vue
-<script>
-import { defineComponent } from "vue";
+<script setup>
 import { useIsFetching } from "vue-query";
 
-export default defineComponent({
-  setup(props) {
-    const isFetching = useIsFetching();
-    return { isFetching };
-  },
-});
+const isFetching = useIsFetching();
 </script>
 
 <template>

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -1,0 +1,39 @@
+### Use custom composables (hooks) for queries
+
+We find it useful to abstract queries into custom reusable composables and put them into separate files.
+
+```ts
+// component-folder/query.ts
+import { useQuery } from "vue-query";
+
+export function useTodoQuery(todoId, { enabled }) {
+  return useQuery(
+    ["todos", todoId],
+    () => axios.get(`/todos/${todoId.value}`),
+    {
+      enabled,
+      select: (todo) => todo.data,
+    }
+  );
+}
+```
+
+```vue
+<script>
+import { ref } from "vue";
+import { useTodoQuery } from "./query.ts";
+
+const todoId = ref(null);
+
+const { isLoading, data } = useTodosQuery(todoId, {
+  enabled: computed(() => !!todoId),
+});
+</script>
+
+<template>...</template>
+```
+
+It has the following advantages:
+
+- the custom hook can easily be reused acrossed multiple components when they need access to the same data
+- the component's logic is free from query implementation details => better separation of concerns

--- a/docs/guides/dependent-queries.md
+++ b/docs/guides/dependent-queries.md
@@ -2,25 +2,25 @@ Dependent (or serial) queries depend on previous ones to finish before they can 
 
 ```js
 // Main Query - get the user
-function getUser(email) {
+function useUserQuery(email) {
   return useQuery(["user", email], () => getUserByEmail(email.value));
 }
 
 // Dependant query - get the user's projects
-function getUserProjects(userId, { enabled }) {
+function useUserProjectsQuery(userId, { enabled }) {
   return useQuery(["projects", userId], () => getProjectsByUser(userId.value), {
     enabled, // The query will not execute until `enabled == true`
   });
 }
 
 // Get the user
-const { data: user } = getUser(email);
+const { data: user } = useUserQuery(email);
 
 const userId = computed(() => user.value?.id);
 const enabled = computed(() => !!user.value?.id);
 
 // Then get the user's projects
-const { isIdle, data: projects } = getUserProjects(userId, { enabled });
+const { isIdle, data: projects } = useUserProjectsQuery(userId, { enabled });
 
 // isIdle will be `true` until `enabled` is true and the query begins to fetch.
 // It will then go to the `isLoading` stage and hopefully the `isSuccess` stage :)

--- a/docs/guides/dependent-queries.md
+++ b/docs/guides/dependent-queries.md
@@ -1,20 +1,26 @@
 Dependent (or serial) queries depend on previous ones to finish before they can execute. To achieve this, it's as easy as using the `enabled` option to tell a query when it is ready to run:
 
 ```js
+// Main Query - get the user
+function getUser(email) {
+  return useQuery(["user", email], () => getUserByEmail(email.value));
+}
+
+// Dependant query - get the user's projects
+function getUserProjects(userId, { enabled }) {
+  return useQuery(["projects", userId], () => getProjectsByUser(userId.value), {
+    enabled, // The query will not execute until `enabled == true`
+  });
+}
+
 // Get the user
-const { data: user } = useQuery(["user", email], getUserByEmail);
+const { data: user } = getUser(email);
 
 const userId = computed(() => user.value?.id);
 const enabled = computed(() => !!user.value?.id);
 
 // Then get the user's projects
-const { isIdle, data: projects } = useQuery(
-  ["projects", userId],
-  () => getProjectsByUser(userId.value),
-  {
-    enabled, // The query will not execute until the userId exists
-  }
-);
+const { isIdle, data: projects } = getUserProjects(userId, { enabled });
 
 // isIdle will be `true` until `enabled` is true and the query begins to fetch.
 // It will then go to the `isLoading` stage and hopefully the `isSuccess` stage :)

--- a/docs/guides/disabling-queries.md
+++ b/docs/guides/disabling-queries.md
@@ -11,20 +11,18 @@ When `enabled` is `false`:
 - The query will ignore query client `invalidateQueries` and `refetchQueries` calls that would normally result in the query refetching.
 - `refetch` can be used to manually trigger the query to fetch.
 
+?> The example below uses `<script setup>` syntax.
+
 ```vue
-<script>
-import { defineComponent } from "vue";
+<script setup>
 import { useQuery } from "vue-query";
 
-export default defineComponent({
-  setup(props) {
-    const { isIdle, isError, data, error, isFetching, refetch } = useQuery(
-      "todos",
-      fetchTodoList,
-      { enabled: false }
-    );
-    return { isIdle, isError, data, error, isFetching, refetch };
-  },
+function useTodosQuery({ enabled }) {
+  return useQuery("todos", fetchTodoList, { enabled });
+}
+
+const { isIdle, isError, data, error, isFetching, refetch } = useTodosQuery({
+  enabled: false,
 });
 </script>
 

--- a/docs/guides/disabling-queries.md
+++ b/docs/guides/disabling-queries.md
@@ -11,8 +11,6 @@ When `enabled` is `false`:
 - The query will ignore query client `invalidateQueries` and `refetchQueries` calls that would normally result in the query refetching.
 - `refetch` can be used to manually trigger the query to fetch.
 
-?> The example below uses `<script setup>` syntax.
-
 ```vue
 <script setup>
 import { useQuery } from "vue-query";

--- a/docs/guides/infinite-queries.md
+++ b/docs/guides/infinite-queries.md
@@ -38,40 +38,32 @@ With this information, we can create a "Load More" UI by:
 ?> Note: It's very important you do not call `fetchNextPage` with arguments unless you want them to override the `pageParam` data returned from the `getNextPageParam` function.  
 Do not do this: `<button @click={fetchNextPage} />` as this would send the onClick event to the `fetchNextPage` function.
 
+?> The example below uses `<script setup>` syntax.
+
 ```vue
-<script>
+<script setup>
 import { defineComponent } from "vue";
 import { useInfiniteQuery } from "vue-query";
 
 const fetchProjects = ({ pageParam = 0 }) =>
   fetch("/api/projects?cursor=" + pageParam);
 
-export default defineComponent({
-  setup() {
-    const {
-      data,
-      error,
-      fetchNextPage,
-      hasNextPage,
-      isFetching,
-      isFetchingNextPage,
-      isLoading,
-      isError,
-    } = useInfiniteQuery("projects", fetchProjects, {
-      getNextPageParam: (lastPage, pages) => lastPage.nextCursor,
-    });
-    return {
-      data,
-      error,
-      fetchNextPage,
-      hasNextPage,
-      isFetching,
-      isFetchingNextPage,
-      isLoading,
-      isError,
-    };
-  },
-});
+function useProjectsInfiniteQuery() {
+  return useInfiniteQuery("projects", fetchProjects, {
+    getNextPageParam: (lastPage, pages) => lastPage.nextCursor,
+  });
+}
+
+const {
+  data,
+  error,
+  fetchNextPage,
+  hasNextPage,
+  isFetching,
+  isFetchingNextPage,
+  isLoading,
+  isError,
+} = useProjectsInfiniteQuery();
 </script>
 
 <template>
@@ -107,9 +99,13 @@ If an infinite query's results are ever removed from the `queryCache`, the pagin
 If you only want to actively refetch a subset of all pages, you can pass the `refetchPage` function to `refetch` returned from `useInfiniteQuery`.
 
 ```js
-const { refetch } = useInfiniteQuery("projects", fetchProjects, {
-  getNextPageParam: (lastPage, pages) => lastPage.nextCursor,
-});
+function useProjectsInfiniteQuery() {
+  return useInfiniteQuery("projects", fetchProjects, {
+    getNextPageParam: (lastPage, pages) => lastPage.nextCursor,
+  });
+}
+
+const { refetch } = useProjectsInfiniteQuery();
 
 // only refetch the first page
 refetch({ refetchPage: (page, index) => index === 0 });
@@ -132,9 +128,13 @@ You can pass custom variables to the `fetchNextPage` function which will overrid
 const fetchProjects = ({ pageParam = 0 }) =>
   fetch("/api/projects?cursor=" + pageParam);
 
-const { fetchNextPage } = useInfiniteQuery("projects", fetchProjects, {
-  getNextPageParam: (lastPage, pages) => lastPage.nextCursor,
-});
+function useProjectsInfiniteQuery() {
+  return useInfiniteQuery("projects", fetchProjects, {
+    getNextPageParam: (lastPage, pages) => lastPage.nextCursor,
+  });
+}
+
+const { fetchNextPage } = useProjectsInfiniteQuery();
 
 // Pass your own page param
 const skipToCursor50 = () => fetchNextPage({ pageParam: 50 });
@@ -156,12 +156,14 @@ useInfiniteQuery("projects", fetchProjects, {
 Sometimes you may want to show the pages in reversed order. If this is case, you can use the `select` option:
 
 ```js
-useInfiniteQuery("projects", fetchProjects, {
-  select: (data) => ({
-    pages: [...data.pages].reverse(),
-    pageParams: [...data.pageParams].reverse(),
-  }),
-});
+function useProjectsInfiniteQuery() {
+  return useInfiniteQuery("projects", fetchProjects, {
+    select: (data) => ({
+      pages: [...data.pages].reverse(),
+      pageParams: [...data.pageParams].reverse(),
+    }),
+  });
+}
 ```
 
 ## What if I want to manually update the infinite query?

--- a/docs/guides/infinite-queries.md
+++ b/docs/guides/infinite-queries.md
@@ -38,8 +38,6 @@ With this information, we can create a "Load More" UI by:
 ?> Note: It's very important you do not call `fetchNextPage` with arguments unless you want them to override the `pageParam` data returned from the `getNextPageParam` function.  
 Do not do this: `<button @click={fetchNextPage} />` as this would send the onClick event to the `fetchNextPage` function.
 
-?> The example below uses `<script setup>` syntax.
-
 ```vue
 <script setup>
 import { defineComponent } from "vue";

--- a/docs/guides/initial-query-data.md
+++ b/docs/guides/initial-query-data.md
@@ -90,7 +90,7 @@ A good example of this would be searching the cached data from a todos list quer
 ```js
 function useTodoQuery(todoId) {
   return useQuery(["todo", todoId], () => fetch(`/todos/${todoId.value}`), {
-      // Use a todo from the 'todos' query as the initial data for this todo query
+    // Use a todo from the 'todos' query as the initial data for this todo query
     initialData: queryClient.getQueryData("todos")?.find((d) => d.id === todoId.value);
   });
 }

--- a/docs/guides/initial-query-data.md
+++ b/docs/guides/initial-query-data.md
@@ -14,9 +14,15 @@ If and when this is the case, you can use the `config.initialData` option to set
 !> IMPORTANT: `initialData` is persisted to the cache, so it is not recommended to provide placeholder, partial or incomplete data to this option and instead use `placeholderData`
 
 ```js
-const result = useQuery("todos", () => fetch("/todos"), {
-  initialData: initialTodos,
-});
+function useTodosQuery() {
+  const initialTodos = [...];
+
+  return useQuery("todos", () => fetch("/todos"), {
+    initialData: initialTodos,
+  });
+}
+
+const { data, isLoading } = useTodosQuery();
 ```
 
 ### `staleTime` and `initialDataUpdatedAt`
@@ -27,19 +33,29 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
 
   ```js
   // Will show initialTodos immediately, but also immediately refetch todos after mount
-  const result = useQuery("todos", () => fetch("/todos"), {
-    initialData: initialTodos,
-  });
+  function useTodosQuery() {
+    const initialTodos = [...];
+
+    return useQuery("todos", () => fetch("/todos"), {
+      initialData: initialTodos,
+    });
+  }
+
+  const { data, isLoading } = useTodosQuery();
   ```
 
 - If you configure your query observer with `initialData` and a `staleTime` of `1000 ms`, the data will be considered fresh for that same amount of time, as if it was just fetched from your query function.
 
   ```js
   // Show initialTodos immediately, but won't refetch until another interaction event is encountered after 1000 ms
-  const result = useQuery("todos", () => fetch("/todos"), {
-    initialData: initialTodos,
-    staleTime: 1000,
-  });
+  function useTodosQuery() {
+    const initialTodos = [...];
+
+    return useQuery("todos", () => fetch("/todos"), {
+      initialData: initialTodos,
+      staleTime: 1000,
+    });
+  }
   ```
 
 - So what if your `initialData` isn't totally fresh?  
@@ -49,12 +65,16 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
 
   ```js
   // Show initialTodos immeidately, but won't refetch until another interaction event is encountered after 1000 ms
-  const result = useQuery('todos', () => fetch('/todos'), {
-    initialData: initialTodos,
-    staleTime: 60 * 1000 // 1 minute
-    // This could be 10 seconds ago or 10 minutes ago
-    initialDataUpdatedAt: initialTodosUpdatedTimestamp // eg. 1608412420052
-  })
+  function useTodosQuery() {
+    const initialTodos = [...];
+
+    return useQuery("todos", () => fetch("/todos"), {
+      initialData: initialTodos,
+      staleTime: 60 * 1000 // 1 minute
+      // This could be 10 seconds ago or 10 minutes ago
+      initialDataUpdatedAt: initialTodosUpdatedTimestamp // eg. 1608412420052
+    });
+  }
   ```
 
   This option allows the staleTime to be used for its original purpose, determining how fresh the data needs to be, while also allowing the data to be refetched on mount if the `initialData` is older than the `staleTime`.  
@@ -62,31 +82,18 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
 
 ?> If you would rather treat your data as `prefetched data`, we recommend that you use the `prefetchQuery` or `fetchQuery` APIs to populate the cache beforehand, thus letting you configure your `staleTime` independently from your `initialData`
 
-### Initial Data Function
-
-If the process for accessing a query's initial data is intensive or just not something you want to perform on every render, you can pass a function as the `initialData` value.  
-This function will be executed only once when the query is initialized, saving you precious memory and/or CPU:
-
-```js
-const result = useQuery("todos", () => fetch("/todos"), {
-  initialData: () => {
-    return getExpensiveTodos();
-  },
-});
-```
-
 ### Initial Data from Cache
 
 In some circumstances, you may be able to provide the initial data for a query from the cached result of another.  
 A good example of this would be searching the cached data from a todos list query for an individual todo item, then using that as the initial data for your individual todo query:
 
 ```js
-const result = useQuery(["todo", todoId], () => fetch("/todos"), {
-  initialData: () => {
-    // Use a todo from the 'todos' query as the initial data for this todo query
-    return queryClient.getQueryData("todos")?.find((d) => d.id === todoId);
-  },
-});
+function useTodoQuery(todoId) {
+  return useQuery(["todo", todoId], () => fetch(`/todos/${todoId.value}`), {
+      // Use a todo from the 'todos' query as the initial data for this todo query
+    initialData: queryClient.getQueryData("todos")?.find((d) => d.id === todoId.value);
+  });
+}
 ```
 
 ### Initial Data from the cache with `initialDataUpdatedAt`
@@ -96,11 +103,14 @@ Instead of using an artificial `staleTime` to keep your query from refetching im
 This provides the query instance with all the information it needs to determine if and when the query needs to be refetched, regardless of initial data being provided.
 
 ```js
-const result = useQuery(["todo", todoId], () => fetch(`/todos/${todoId}`), {
-  initialData: () =>
-    queryClient.getQueryData("todos")?.find((d) => d.id === todoId),
-  initialDataUpdatedAt: () => queryClient.getQueryState("todos")?.dataUpdatedAt,
-});
+function useTodoQuery(todoId) {
+  return useQuery(["todo", todoId], () => fetch(`/todos/${todoId.value}`), {
+    initialData: queryClient
+      .getQueryData("todos")
+      ?.find((d) => d.id === todoId.value),
+    initialDataUpdatedAt: queryClient.getQueryState("todos")?.dataUpdatedAt,
+  });
+}
 ```
 
 ### Conditional Initial Data from Cache
@@ -109,8 +119,8 @@ If the source query you're using to look up the initial data from is old, you ma
 To make this decision easier, you can use the `queryClient.getQueryState` method instead to get more information about the source query, including a `state.dataUpdatedAt` timestamp you can use to decide if the query is "fresh" enough for your needs:
 
 ```js
-const result = useQuery(["todo", todoId], () => fetch(`/todos/${todoId}`), {
-  initialData: () => {
+function useTodoQuery(todoId) {
+  const getInitialData = () => {
     // Get the query state
     const state = queryClient.getQueryState("todos");
 
@@ -121,6 +131,10 @@ const result = useQuery(["todo", todoId], () => fetch(`/todos/${todoId}`), {
     }
 
     // Otherwise, return undefined and let it fetch from a hard loading state!
-  },
-});
+  };
+
+  return useQuery(["todo", todoId], () => fetch(`/todos/${todoId.value}`), {
+    initialData: getInitialData(),
+  });
+}
 ```

--- a/docs/guides/paginated-queries.md
+++ b/docs/guides/paginated-queries.md
@@ -1,7 +1,7 @@
 Rendering paginated data is a very common UI pattern and in Vue Query, it **"just works"** by including the page information in the query key:
 
 ```js
-const result = useQuery(["projects", { page }], fetchProjects);
+const result = useQuery(["projects", page], fetchProjects);
 ```
 
 However, if you run this simple example, you might notice something strange:

--- a/docs/guides/parallel-queries.md
+++ b/docs/guides/parallel-queries.md
@@ -16,18 +16,18 @@ const projectsQuery = useQuery('projects', fetchProjects)
 
 ## Dynamic Parallel Queries with `useQueries`
 
-If the number of queries you need to execute is changing from render to render, you cannot use manual querying since that would violate the rules of hooks. Instead, Vue Query provides a `useQueries` hook, which you can use to dynamically execute as many queries in parallel as you'd like.
+If the number of queries you need to execute is changing over the lifetime of a component, you cannot use manual querying since that would violate the rules of Composables - they should be executed synchronously in `<script setup>` or the `setup()` function. Instead, Vue Query provides a `useQueries` hook, which you can use to dynamically execute as many queries in parallel as you'd like.
 
-`useQueries` accepts an **array of query options objects** and returns an **array of query results**:
+`useQueries` accepts an **array of query options objects** and returns a **reactive array of query results**:
 
 ```js
 const users = computed(...)
-const userQueries = useQueries(
-  users.value.map(user => {
+const usersQueriesOptions = computed(() => users.value.map(user => {
     return {
       queryKey: ['user', user.id],
       queryFn: () => fetchUserById(user.id),
     }
   })
-)
+);
+const userQueries = useQueries(usersQueriesOptions)
 ```

--- a/docs/guides/placeholder-query-data.md
+++ b/docs/guides/placeholder-query-data.md
@@ -16,20 +16,15 @@ There are a few ways to supply placeholder data for a query to the cache before 
 ### Placeholder Data as a Value
 
 ```js
-const result = useQuery("todos", () => fetch("/todos"), {
-  placeholderData: placeholderTodos,
-});
-```
+function useTodosQuery() {
+  const placeholderTodos = [...];
 
-### Placeholder Data as a Function
-
-```js
-function generateFakeTodos() {
-  // fake todos
+  return useQuery("todos", () => fetch("/todos"), {
+    placeholderData: placeholderTodos,
+  });
 }
-const result = useQuery("todos", () => fetch("/todos"), {
-  placeholderData: generateFakeTodos(),
-});
+
+const { data, isLoading } = useTodosQuery();
 ```
 
 ### Placeholder Data from Cache
@@ -38,16 +33,20 @@ In some circumstances, you may be able to provide the placeholder data for a que
 A good example of this would be searching the cached data from a blog post list query for a preview version of the post, then using that as the placeholder data for your individual post query:
 
 ```js
-const result = useQuery(
-  ["blogPost", blogPostId],
-  () => fetch(`/blogPosts/${blogPostId}`),
-  {
-    placeholderData: () => {
-      // Use the smaller/preview version of the blogPost from the 'blogPosts' query as the placeholder data for this blogPost query
-      return queryClient
-        .getQueryData("blogPosts")
-        ?.find((d) => d.id === blogPostId);
-    },
-  }
-);
+function useBlogPostQuery(blogPostId) {
+  return useQuery(
+    ["blogPost", blogPostId],
+    () => fetch(`/blogPosts/${blogPostId.value}`),
+    {
+      placeholderData: () => {
+        // Use the smaller/preview version of the blogPost from the 'blogPosts' query as the placeholder data for this blogPost query
+        return queryClient
+          .getQueryData("blogPosts")
+          ?.find((d) => d.id === blogPostId.value);
+      },
+    }
+  );
+}
+
+const { data, isLoading } = useBlogPostQuery(blogPostId);
 ```

--- a/docs/guides/queries.md
+++ b/docs/guides/queries.md
@@ -28,23 +28,17 @@ Beyond those primary states, more information is available depending on the stat
 - `data` - If the query is in a `success` state, the data is available via the `data` property.
 - `isFetching` - In any state, if the query is fetching at any time (including background refetching) `isFetching` will be `true`.
 
+?> Every property of the `result` object is wrapped into a `ref`, so it can be safely destructured while retaining reactivity.
+
 For **most** queries, it's usually sufficient to check for the `isLoading` state, then the `isError` state, then finally, assume that the data is available and render the successful state:
 
+?> The example below uses `<script setup>` syntax.
+
 ```vue
-<script>
-import { defineComponent } from "vue";
+<script setup>
 import { useQuery } from "vue-query";
 
-export default defineComponent({
-  name: "Todo",
-  setup(props) {
-    const { isLoading, isError, data, error } = useQuery(
-      "todos",
-      fetchTodoList
-    );
-    return { isLoading, isError, data, error };
-  },
-});
+const { isLoading, isError, data, error } = useQuery("todos", fetchTodoList);
 </script>
 
 <template>
@@ -60,17 +54,10 @@ export default defineComponent({
 If booleans aren't your thing, you can always use the `status` state as well:
 
 ```vue
-<script>
-import { defineComponent } from "vue";
+<script setup>
 import { useQuery } from "vue-query";
 
-export default defineComponent({
-  name: "Todo",
-  setup(props) {
-    const { status, data, error } = useQuery("todos", fetchTodoList);
-    return { status, data, error };
-  },
-});
+const { status, data, error } = useQuery("todos", fetchTodoList);
 </script>
 
 <template>

--- a/docs/guides/queries.md
+++ b/docs/guides/queries.md
@@ -38,7 +38,11 @@ For **most** queries, it's usually sufficient to check for the `isLoading` state
 <script setup>
 import { useQuery } from "vue-query";
 
-const { isLoading, isError, data, error } = useQuery("todos", fetchTodoList);
+function useTodosQuery() {
+  return useQuery("todos", fetchTodoList);
+}
+
+const { isLoading, isError, data, error } = useTodosQuery();
 </script>
 
 <template>
@@ -57,7 +61,11 @@ If booleans aren't your thing, you can always use the `status` state as well:
 <script setup>
 import { useQuery } from "vue-query";
 
-const { status, data, error } = useQuery("todos", fetchTodoList);
+function useTodosQuery() {
+  return useQuery("todos", fetchTodoList);
+}
+
+const { status, data, error } = useTodosQuery();
 </script>
 
 <template>

--- a/docs/guides/queries.md
+++ b/docs/guides/queries.md
@@ -32,8 +32,6 @@ Beyond those primary states, more information is available depending on the stat
 
 For **most** queries, it's usually sufficient to check for the `isLoading` state, then the `isError` state, then finally, assume that the data is available and render the successful state:
 
-?> The example below uses `<script setup>` syntax.
-
 ```vue
 <script setup>
 import { useQuery } from "vue-query";


### PR DESCRIPTION
## Changes
1. Moved "Examples" section in the Sidebar to the bottom. 
Reason: all the examples are slow to load and don't really work (there are always different errors happening).
In general, I think developers look for examples after the reading the guides (to see how it's really working)
Also ReactQuery has "Example" section after the Guides.

2. Use `<script setup>` syntax to remove boilerplate from the code examples and make the usage of VueQuery more clear.
That syntax is available to Vue2 users as well via a separate plugin. Not sure if it's worth mentioning.

3. Abstracted away the usage of VueQuery hooks into custom composables.
Reason: It's a best practice to abstract away the usage of ReactQuery into custom hooks. For example, the ReactQuery's maintainer does it and puts those custom hooks into separate files. I also find huge benefits in doing so. ReactQuery documentation doesn't mention it and doesn't follow it and that, I think, is the reason why many developers struggle with ReactQuery and have bad experience using it. 
![image](https://user-images.githubusercontent.com/427621/151146057-d5c99992-8932-416c-b24f-dbd051523c5c.png)

4. Some fixes