### PR TITLE
Allow directly awaiting on useQuery

### DIFF
--- a/src/vue/useQuery.ts
+++ b/src/vue/useQuery.ts
@@ -64,8 +64,13 @@ export function useQuery<
 
   const asyncDataPromise = new Promise<UseQueryReturnType<TData, TError>>(
     (resolve) => {
+      if (returnValue.isIdle.value || returnValue.isFetched.value) {
+        resolve(returnValue);
+        return;
+      }
+
       const stopWatcher = watch(returnValue.isFetched, (isFetched) => {
-        if (isFetched || returnValue.isIdle) {
+        if (isFetched) {
           resolve(returnValue);
           stopWatcher();
         }


### PR DESCRIPTION
- allow you to wait until the request receives the first value like in the Nuxt 3. [See code](https://github.com/nuxt/framework/blob/36a42a4d708085b980b167a25f0cedb773385a76/packages/nuxt3/src/app/composables/asyncData.ts#L168).

It can really help with nuxt. Instead of this code:

```ts
const {
  data: categories,
  suspense,
} = useQuery('key', () => fetch('api/categories'))

onServerPrefetch(async() => {
  await suspense()
})
```

We will be able to write this:

```ts
const {
  data: categories,
} = await useQuery('key', () => fetch('api/categories'))
```

**It is backward compatible. Any previous code works as before.**