### PR TITLE
fix: use generic TQueryKey in useQuery and useInfiniteQuery parameters

### DIFF
--- a/src/vue/useInfiniteQuery.ts
+++ b/src/vue/useInfiniteQuery.ts
@@ -50,7 +50,7 @@ export function useInfiniteQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
 >(
-  queryKey: QueryKey,
+  queryKey: TQueryKey,
   options?: Omit<
     UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
     "queryKey"
@@ -63,7 +63,7 @@ export function useInfiniteQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
 >(
-  queryKey: QueryKey,
+  queryKey: TQueryKey,
   queryFn: QueryFunction<TQueryFnData, TQueryKey>,
   options?: Omit<
     UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,

--- a/src/vue/useQuery.ts
+++ b/src/vue/useQuery.ts
@@ -26,7 +26,7 @@ export function useQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
 >(
-  queryKey: QueryKey,
+  queryKey: TQueryKey,
   options?: Omit<
     UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
     "queryKey"
@@ -38,8 +38,8 @@ export function useQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
 >(
-  queryKey: QueryKey,
-  queryFn: QueryFunction<TQueryFnData>,
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, TQueryKey>,
   options?: Omit<
     UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
     "queryKey" | "queryFn"


### PR DESCRIPTION
Currently, the `useQuery` and `useInfiniteQuery` composables use the regular `QueryKey` type instead of its generic variant, so there is no possibility of using a custom `QueryKey`. This PR will fix it.