### PR TITLE
fix: install devtools on root component instance in Vue 2

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,6 +12,20 @@ yarn add vue-query
 
 Before starting using Vue Query, you need to initialize it using `VueQueryPlugin`
 
+Vue 2.7.x or Vue 2.x with @vue/composition-api
+
+```ts
+import { VueQueryPlugin } from 'vue-query'
+
+Vue.use(VueQueryPlugin)
+
+new Vue({
+  render: h => h(App),
+  VueQueryPlugin: true
+}).$mount('#app')
+```
+
+Vue 3 
 ```ts
 import { VueQueryPlugin } from "vue-query";
 

--- a/src/vuejs/vueQueryPlugin.ts
+++ b/src/vuejs/vueQueryPlugin.ts
@@ -78,7 +78,6 @@ export const VueQueryPlugin = {
     /* istanbul ignore next */
     if (isVue2) {
       // Workaround for Vue2 calling mixin multiple times
-      let devtoolsRegistered = false;
       app.mixin({
         beforeCreate() {
           // HACK: taken from provide(): https://github.com/vuejs/composition-api/blob/master/src/apis/inject.ts#L30
@@ -92,10 +91,9 @@ export const VueQueryPlugin = {
 
           this._provided[clientKey] = client;
 
-          if (!devtoolsRegistered) {
+          if (this.$options.VueQueryPlugin) {
             if (process.env.NODE_ENV === "development") {
               setupDevtools(this, client);
-              devtoolsRegistered = true;
             }
           }
         },


### PR DESCRIPTION
Hey @DamianOsipiuk I appreciate your work on #207. I did some further digging and as you've probably seen `app.mixin` is global and applies to every component which was leading to the multiples of errors. Although you prevented it from registering multiple times, I found it was now missing from my devtools. 

It seems it specifically needs to target the root component instance as the Vue Devtools docs recommend here: https://devtools.vuejs.org/plugin/plugins-guide.html#vue-2

This PR should show how that's done successfully and added a change to the docs to give examples of both Vue 2 and Vue 3. I'm not sure how you handle the releases to vue-query@1 and vue-query@2 so feel free to make changes if this doesnt work for both. It might technically be a breaking change since you now need to add the key on `new Vue({})` for it to register the dev tools.  




 