### PR TITLE
Making as many options as possible a MaybeRef

### DIFF
--- a/src/vuejs/types.ts
+++ b/src/vuejs/types.ts
@@ -3,14 +3,14 @@ import type {
   QueryObserverOptions,
   InfiniteQueryObserverOptions,
 } from "@tanstack/query-core";
-import { Ref, UnwrapRef } from "vue-demi";
+import type { Ref } from "vue-demi";
 import type { QueryClient } from "vue-query";
 
 export type MaybeRef<T> = Ref<T> | T;
 export type MaybeRefDeep<T> = T extends Function
   ? T
   : MaybeRef<
-      T extends object
+      T extends Array<unknown> | Record<string, unknown>
         ? {
             [Property in keyof T]: MaybeRefDeep<T[Property]>;
           }
@@ -30,31 +30,9 @@ export type VueQueryObserverOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
-> = {
-  [Property in keyof QueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryData,
-    TQueryKey
-  >]: Property extends "queryFn"
-    ? QueryObserverOptions<
-        TQueryFnData,
-        TError,
-        TData,
-        TQueryData,
-        UnwrapRef<TQueryKey>
-      >[Property]
-    : MaybeRef<
-        QueryObserverOptions<
-          TQueryFnData,
-          TError,
-          TData,
-          TQueryData,
-          TQueryKey
-        >[Property]
-      >;
-};
+> = MaybeRefDeep<
+  QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
+>;
 
 // A Vue version of InfiniteQueryObserverOptions from "@tanstack/query-core"
 // Accept refs as options
@@ -64,28 +42,6 @@ export type VueInfiniteQueryObserverOptions<
   TData = unknown,
   TQueryData = unknown,
   TQueryKey extends QueryKey = QueryKey
-> = {
-  [Property in keyof InfiniteQueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryData,
-    TQueryKey
-  >]: Property extends "queryFn"
-    ? InfiniteQueryObserverOptions<
-        TQueryFnData,
-        TError,
-        TData,
-        TQueryData,
-        UnwrapRef<TQueryKey>
-      >[Property]
-    : MaybeRef<
-        InfiniteQueryObserverOptions<
-          TQueryFnData,
-          TError,
-          TData,
-          TQueryData,
-          TQueryKey
-        >[Property]
-      >;
-};
+> = MaybeRefDeep<
+  InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
+>;

--- a/src/vuejs/useMutation.ts
+++ b/src/vuejs/useMutation.ts
@@ -17,17 +17,15 @@ import type {
 } from "@tanstack/query-core";
 import { cloneDeepUnref, isQueryKey, updateState } from "./utils";
 import { useQueryClient } from "./useQueryClient";
-import { WithQueryClientKey } from "./types";
+import { WithQueryClientKey, MaybeRefDeep } from "./types";
 
-type MutationResult<TData, TError, TVariables, TContext> = Omit<
+type MutationResult<TData = unknown, TError = unknown, TVariables = void, TContext = unknown> = Omit<
   MutationObserverResult<TData, TError, TVariables, TContext>,
   "mutate" | "reset"
 >;
 
-export type UseMutationOptions<TData, TError, TVariables, TContext> =
-  WithQueryClientKey<
-    MutationObserverOptions<TData, TError, TVariables, TContext>
-  >;
+export type UseMutationOptions<TData = unknown, TError = unknown, TVariables = void, TContext = unknown> =
+  WithQueryClientKey<MaybeRefDeep<MutationObserverOptions<TData, TError, TVariables, TContext>>>;
 
 type MutateSyncFunction<
   TData = unknown,


### PR DESCRIPTION
This is still a WIP. I just wanted to ask you a few things, such as:

- Why did you create the type `MaybeRefDeep` and then not use it? Doesn't it do exactly what you are trying to do a few lines later, but then much less verbose?
- I changed `MaybeRefDeep` a bit, first I replaced `object` with `Record<string, unknown>`, because if you use `object`, then you also include `Date` for example.
- I also included arrays in `MaybeRefDeep` and I just wanted to check whether you agree with that?

Finally, your pre-commit hook failed:

```
$ git commit --file=/var/folders/cj/_1wry0kd7x74t8f3wfnkz2l00000gn/T/FB5AD48F-E541-4E5B-AE10-42EBD75C2FF3

.husky/commit-msg: line 4: npx: command not found
husky - commit-msg hook exited with code 127 (error)
husky - command not found in PATH=/Applications/Fork.app/Contents/Resources/git-instance/libexec/git-core:/Applications/Fork.app/Contents/Resources/git-instance/git-lfs:/Applications/Fork.app/Contents/Resources/gitflow-avh:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

Is there anything I can do to make this work?