### PR TITLE
docs: clarify that status === 'loading' is equivalent to isLoading

### DIFF
--- a/docs/guides/background-fetching-indicators.md
+++ b/docs/guides/background-fetching-indicators.md
@@ -1,6 +1,6 @@
-A query's `status === 'loading'` state is sufficient enough to show the initial hard-loading state for a query, but sometimes you may want to display an additional indicator that a query is refetching in the background.
+A query's `isLoading` or `status === 'loading'` states are sufficient enough to show the initial hard-loading state for a query, but sometimes you may want to display an additional indicator that a query is refetching in the background.
 
-To do this, queries also supply you with an `isFetching` boolean that you can use to show that it's in a fetching state, regardless of the state of the `status` variable:
+To do this, queries also supply you with an `isFetching` boolean that you can use to show that it's in a fetching state, regardless of the state of the `isLoading` or `status` variables:
 
 ```vue
 <script setup>


### PR DESCRIPTION
In the section on background fetching indicators in the docs, make it clearer that `status === 'loading'` is equivalent to the `isLoading` variable.